### PR TITLE
Fix: use pathlib for cross-platform path handling in robotdashboardli…

### DIFF
--- a/example/listener/robotdashboardlistener.py
+++ b/example/listener/robotdashboardlistener.py
@@ -4,6 +4,7 @@ from requests import post, get, delete
 from requests.exceptions import ConnectionError
 from robot.libraries.BuiltIn import BuiltIn
 from time import sleep
+from pathlib import Path
 
 # for usage with a "robot.toml" see robot.toml in this folder
 
@@ -57,7 +58,13 @@ class robotdashboardlistener:
         if (
             self.last_execution and self.last_execution == "1"
         ):  # pabot usage and it's the very last execution
-            self.path = self.path.rsplit("\\", 1)[0] + f"\..\..\{self.output}"
+            # Original code caused issues on Linux due to hardcoded Windows-style path resulting in invalid escape sequences error for linux users:
+            ## self.path = self.path.rsplit("\\", 1)[0] + f"\..\..\{self.output}"
+
+            # The revised code below uses pathlib for cross-platform path handling written by siddharthsinghchaudhari.
+            # It navigates three levels up from the current path and appends the output file name.
+            # This approach works correctly on both Windows and Linux systems.
+            self.path = str(Path(self.path).parent.parent.parent / self.output)
             # added to make sure the output file is created, make this longer if the output generation is longer!
             timeout = 0
             while timeout < 10:


### PR DESCRIPTION
### Summary

Fixes a path-handling issue in `robotdashboardlistener.py` for Linux users.

### Description

The original script used Windows-style paths, which caused issues on Linux-based environments. This update replaces manual path handling with Python's `pathlib` module, ensuring compatibility across operating systems.

### Changes Made

- Replaced hardcoded path logic with `pathlib.Path` operations.
- Tested successfully on a Linux environment.

Fixes #52 

With warm regards,
Siddharth Singh Chaudhari

Ph.: +91 7983312614
email- siddharthas222@gmail.com

