### PR TITLE
Pr/add projects section to overview

### DIFF
--- a/atest/testsuites/02_overview.robot
+++ b/atest/testsuites/02_overview.robot
@@ -16,18 +16,7 @@ Validate Overview Page Base View
     Open Overview Page
     Validate Component    id=overviewStatisticsSection    name=baseView    folder=overview
 
-Validate Overview Page Display All Runs
-    Open Overview Page
-    Click    selector=id=switchShowAllRuns
-    Validate Component    id=overviewStatisticsSection    name=allRuns    folder=overview
-
 Validate Overview Page Use Run Tags
     Open Overview Page
     Click    selector=id=switchRunTags
     Validate Component    id=overviewStatisticsSection    name=runTags    folder=overview
-
-Validate Overview Page Display All Runs And Use Run Tags
-    Open Overview Page
-    Click    selector=id=switchShowAllRuns
-    Click    selector=id=switchRunTags
-    Validate Component    id=overviewStatisticsSection    name=allRunsAndRunTags    folder=overview

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -512,6 +512,12 @@
                             </div>
                             <div class="col-auto">
                                 <div class="btn-group">
+                                    <label class="form-check-label ms-2" for="switchRunName">Display by Name</label>
+                                </div>
+                                <div class="btn-group form-switch ms-1">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="switchRunName"/>
+                                </div>
+                            </div>
                             <div class="col-auto">
                                 <div class="btn-group">
                                     <label class="form-check-label ms-2" for="switchRunTags">Display by Tag</label>
@@ -2369,6 +2375,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         var settings = {
             switch: {
                 runTags: false,
+                runName: true,
                 suitePathsSuiteSection: false,
                 suitePathsTestSection: false,
                 suitePathsCompareSection: false,
@@ -3453,8 +3460,23 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         // function to setup eventlisteners for filter buttons
         function setup_sections_filters() {
             update_switch_local_storage("switch.runTags", settings.switch.runTags, true);
-            document.getElementById("switchRunTags").addEventListener("click", function () {
+            update_switch_local_storage("switch.runName", settings.switch.runName, true);
+
+            const switchRunTags = document.getElementById("switchRunTags");
+            const switchRunName = document.getElementById("switchRunName");
+
+            switchRunTags.addEventListener("click", function () {
                 settings.switch.runTags = !settings.switch.runTags
+                update_switch_local_storage("switch.runTags", settings.switch.runTags);
+                ensureOneOn("runTags", "runName", switchRunName);
+                update_switch_local_storage("switch.runName", settings.switch.runName);
+                create_overview_statistics_graphs();
+                create_project_overview();
+            });
+            switchRunName.addEventListener("click", function () {
+                settings.switch.runName = !settings.switch.runName
+                update_switch_local_storage("switch.runName", settings.switch.runName);
+                ensureOneOn("runName", "runTags", switchRunTags);
                 update_switch_local_storage("switch.runTags", settings.switch.runTags);
                 create_overview_statistics_graphs();
                 create_project_overview();
@@ -3714,6 +3736,15 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             });
         }
 
+        // If user turns one off while the other is also off,
+        // automatically re-enable the other one.
+        function ensureOneOn(changedKey, otherKey, otherBox) {
+            if (!settings.switch[changedKey] && !settings.switch[otherKey]) {
+                settings.switch[otherKey] = true;
+                otherBox.checked = true;
+            }
+        }
+
         /////////////////////////////////////
         // FILTER BUTTON CONTENT FUNCTIONS //
         /////////////////////////////////////
@@ -3954,7 +3985,13 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         const isDark = document.documentElement.classList.contains("dark-mode");
         const svg = isDark ? clockDarkSVG: clockLightSVG;
 
-        const projectData = settings.switch.runTags ? projects_by_tag : projects_by_name;
+        const { runName, runTags } = settings.switch;
+        const projectData = runName && runTags
+            ? { ...projects_by_name, ...projects_by_tag }
+            : runName
+            ? projects_by_name
+            : projects_by_tag;
+
 
         // create run cards for each project
         Object.keys(projectData).sort().forEach(projectName => {
@@ -4373,30 +4410,25 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         function create_overview_statistics_graphs() {
             const data = {};
             for (const run of runs) {
-                var name = '';
+                const projects = new Set();
                 if (settings.switch.runTags) {
-                    const tags = run.tags.split(",");
-                    var foundTag = false;
-                    for (const tag of tags) {
-                        if (tag.startsWith('project_')) {
-                            name = tag;
-                            foundTag = true;
-                            break;
-                        }
-                    }
-                    if (!foundTag) name = run.name;
-                } else {
-                    name = run.name;
+                    const tag = run.tags.split(",").find(t => t.startsWith("project_"));
+                    projects.add(tag);
+                }
+                if (settings.switch.runName) {
+                    projects.add(run.name);
                 }
 
-                if (!data[name]) {
-                    data[name] = { runs: [] };
+                for (const project of projects) {
+                    if (!data[project]) {
+                        data[project] = { runs: [] };
+                    }
+                    data[project].runs.push({
+                        stats: [run.passed, run.failed, run.skipped, run.elapsed_s, run.path],
+                        duration: run.elapsed_s,
+                        passed_run: run.failed === 0 ? 1 : 0
+                    });
                 }
-                data[name].runs.push({
-                    stats: [run.passed, run.failed, run.skipped, run.elapsed_s, run.path],
-                    duration: run.elapsed_s,
-                    passed_run: run.failed === 0 ? 1 : 0
-                });
             }
 
             const avg = arr => arr.reduce((a, b) => a + parseFloat(b), 0) / arr.length;

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -4062,7 +4062,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
           const cardsContainer = document.getElementById(`${projectName}_projectRunCardsContainer`);
 
           const durations = projectRuns.map(r => r.elapsed_s);
-          const averageDuration = durations.reduce((a,b) => a + parseFloat(b), 0) / durations.length;
 
           // create section for project in overview if not present
           if (!cardsContainer) create_project_bar(projectName, projectRuns, totalRunsAmount, passRate);
@@ -4077,7 +4076,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
           projectRunsToShow.forEach((run, idx) => {
             const runNumber = projectRunsToShow.length - idx;
-            const createdRunCardId = create_project_run_card(run, projectName, idx, runNumber, passRate, percent, averageDuration)
+            const createdRunCardId = create_project_run_card(run, projectName, idx, runNumber, passRate, percent, durations)
             const createdRunCard = document.getElementById(createdRunCardId);
 
             // group 3 cards into row
@@ -4095,10 +4094,16 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
       }
 
       // create a run card that will be displayed within each project section in overview
-      function create_project_run_card(run, projectName, runIndex, runNumber, passRate, percent, averageDuration) {
+      function create_project_run_card(run, projectName, runIndex, runNumber, passRate, percent, durations) {
+        const avg = arr => arr.reduce((a, b) => a + parseFloat(b), 0) / arr.length;
+
         const stats = [run.passed, run.failed, run.skipped, run.elapsed_s, run.path];
+
         const duration = run.elapsed_s;
         const duration_rounded = Math.round(duration);
+        const durationsForAvg = durations.filter(item => item !== duration);
+        const average = durationsForAvg.length ? avg(durationsForAvg) : duration;
+
         const status = run.failed > 0 ? 'failed' : run.skipped > 0 ? 'skipped' : 'passed';
 
         const logPath = use_logs ? transform_file_path(run.path).replaceAll('\\', '\\\\') : '';
@@ -4107,7 +4112,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         const isDark = document.documentElement.classList.contains("dark-mode");
         const svg = isDark ? clockDarkSVG : clockLightSVG;
 
-        const compares = compare_to_average(duration, averageDuration, percent);
+        const compares = compare_to_average(duration, average, percent);
 
         const projectRunCardHTML = generate_overview_card_html(
             projectName,
@@ -4218,12 +4223,14 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
         // prevents regeneration of run cards, just changes class for duration highlight
         function update_duration_comparison_for_project(projectName, projectRuns, percentage) {
-          const durations = projectRuns.map(r => r.elapsed_s);
-          const averageDuration = durations.reduce((a,b) => a + parseFloat(b), 0) / durations.length;
 
           for (let i = 0; i < projectRuns.length; i++) {
-            comparesElement = document.getElementById(`${projectName}_projectRunCardCompares${i}`);
-            duration = document.getElementById(`${projectName}_projectRunCardComparesValue${i}`).getAttribute("value");
+            const comparesElement = document.getElementById(`${projectName}_projectRunCardCompares${i}`);
+            const duration = document.getElementById(`${projectName}_projectRunCardComparesValue${i}`).getAttribute("value");
+            const durationsForAvg = projectRuns
+                                    .map(r => r.elapsed_s)
+                                    .filter(item => item !== duration);
+            const averageDuration = durationsForAvg.reduce((a,b) => a + parseFloat(b), 0) / durationsForAvg.length;
             comparesElement.className = compare_to_average(duration, averageDuration, percentage);
           }
         }
@@ -4467,7 +4474,9 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                     const path = transform_file_path(rawPath).replaceAll('\\', '\\\\');
                     const runNumber = runList.length - runIndex;
 
-                    const durationsForAvg = runList.map(x => x.duration).slice(1);
+                    const durationsForAvg = runList
+                                            .map(x => x.duration)
+                                            .filter(item => item !== duration);
                     const average = durationsForAvg.length ? avg(durationsForAvg) : duration;
 
                     const compares = compare_to_average(duration, average, overviewDurationPercentage);

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -4180,7 +4180,8 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                                         .reverse()
                                         .filter((_, idx) => idx !== i)
                 const averageDuration = durationsForAvg.reduce((a,b) => a + parseFloat(b), 0) / durationsForAvg.length;
-                comparesElement.className = compare_to_average(duration, averageDuration, percentage);
+                compareClass = compare_to_average(duration, averageDuration, percentage);
+                if (compareClass) comparesElement.classList.add(compareClass);
             }
         }
 

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -4027,6 +4027,19 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
           el.chartInstance = new Chart(el, config);
       }
+
+        // prevents regeneration of run cards, just changes class for duration highlight
+        function update_duration_comparison_for_project(projectName, projectRuns, percentage) {
+          const durations = projectRuns.map(r => r.elapsed_s);
+          const averageDuration = durations.reduce((a,b) => a + parseFloat(b), 0) / durations.length;
+
+          for (let i = 0; i < projectRuns.length; i++) {
+            comparesElement = document.getElementById(`${projectName}_projectRunCardCompares${i}`);
+            duration = document.getElementById(`${projectName}_projectRunCardComparesValue${i}`).getAttribute("value");
+            comparesElement.className = compare_to_average(duration, averageDuration, percentage);
+          }
+        }
+
         ///////////////////////////
         // DATA FILTER FUNCTIONS //
         ///////////////////////////

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -2462,7 +2462,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 set_local_storage_item("theme", "dark");
             }
             setup_theme()
-            setup_dasbhoard_graphs()
+            setup_dashboard_graphs()
         }
 
         // theme function based on browser/machine color scheme
@@ -7503,7 +7503,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 requestAnimationFrame(() => {
                     setup_spinner(true);
                     setup_section_menu_buttons(); // sections have to be visible to update highlighting correctly
-                    setup_dasbhoard_graphs();
+                    setup_dashboard_graphs();
 
                     if (!menuUpdate) {
                         setTimeout(() => {
@@ -7555,7 +7555,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         }
 
         // function that updates all graphs based on the new filtered data and hidden choices
-        function setup_dasbhoard_graphs() {
+        function setup_dashboard_graphs() {
             if (settings.menu.overview) {
                 create_overview_statistics_graphs();
                 update_donut_charts("projectOverviewData");

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -3984,6 +3984,59 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             }
         }
 
+      // create project bar (the collapsables below overview statistic) in overview
+      function create_project_bar(projectName, projectRuns, totalRunsAmount, passRate) {
+          const projectOverviewData = document.getElementById("projectOverviewData");
+          const projectCard = `
+          <div class="card mb-3" id="${projectName}_projectCard">
+                <div class="card-header">
+                    <div class="row">
+                        <div class="col-auto align-self-center">
+                            <div class="btn btn-sm collapse-icon" id="collapse${projectName}_projectBody">
+                                ${arrowRight}
+                            </div>
+                        </div>
+                        <div class="col-4">
+                            <h4>${projectName}</h4>
+                            <h6>Total Runs: ${totalRunsAmount} | Passed Runs: ${passRate}%</h6>
+                        </div>
+                        <div class="d-flex flex-wrap align-items-start col align-items-center">
+                            <div class="col-auto">
+                                <div class="btn-group">
+                                    <label class="form-check-label" for="${projectName}_projectDurationPercentage">Percentage</label>
+                                </div>
+                                <div class="btn-group">
+                                    <select class="form-select form-select-sm mt-1" id="${projectName}_projectDurationPercentage">
+                                        <option value="10">10</option>
+                                        <option value="20" selected="">20</option>
+                                        <option value="30">30</option>
+                                        <option value="40">40</option>
+                                        <option value="50">50</option>
+                                        <option value="60">60</option>
+                                        <option value="70">70</option>
+                                        <option value="80">80</option>
+                                        <option value="90">90</option>
+                                        <option value="100">100</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="card-body" id="${projectName}_projectBody" hidden="">
+                    <div id="${projectName}_projectRunCardsContainer">
+                    </div>
+                </div>
+            </div>
+          `;
+          projectOverviewData.appendChild(document.createRange().createContextualFragment(projectCard));
+          const projectPercentageSelector = document.getElementById(`${projectName}_projectDurationPercentage`);
+          projectPercentageSelector.addEventListener('change', () => {
+              const newPercent = parseInt(projectPercentageSelector.value, 10);
+              update_duration_comparison_for_project(projectName, projectRuns, newPercent);
+          });
+      }
+
       function create_overview_run_donut(run, runIndex, projectName, IsForOverviewStats = true) {
           let idGraphSubString, passed, failed, skipped;
 

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -558,6 +558,11 @@
                 <div class="card-body" id="gridOverview"></div>
             </div>
         </div>
+        <div id="projectOverview" hidden>
+            <!-- Placeholder to add the project overview-->
+            <div id="projectOverviewData">
+            </div>
+        </div>
 
         <div id="dashboard" hidden>
             <div id="topSection" hidden></div>
@@ -3013,11 +3018,13 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             if (hide) {
                 $("#loading").fadeOut(100)
                 $("#overview").fadeIn()
+                $("#projectOverview").fadeIn()
                 $("#dashboard").fadeIn()
                 $("#compare").fadeIn()
                 $("#tables").fadeIn()
             } else {
                 $("#overview").hide()
+                $("#projectOverview").hide()
                 $("#dashboard").hide()
                 $("#compare").hide()
                 $("#tables").hide()
@@ -7263,6 +7270,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 document.getElementById(id).classList.toggle("active", id === item);
                 document.getElementById("customizeLayout").hidden = item == "menuOverview";
             });
+            document.getElementById("projectOverview").hidden = item !== "menuOverview";
             setup_data_and_graphs(true);
         }
 

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -7386,6 +7386,14 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             setup_data_and_graphs(true);
         }
 
+        function update_donut_charts(scopeElement) {
+            const donutContainer = document.getElementById(scopeElement);
+            donutContainer.querySelectorAll(".overview-canvas").forEach(canvas => {
+                const chart = canvas.querySelector("canvas").chartInstance;
+                if (chart) chart.update();
+            });
+        }
+
         // function to setup the menu eventlisteners
         function setup_menu() {
             document.getElementById("menuOverview").addEventListener("click", () => update_menu("menuOverview"));
@@ -7550,6 +7558,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         function setup_dasbhoard_graphs() {
             if (settings.menu.overview) {
                 create_overview_statistics_graphs();
+                update_donut_charts("projectOverviewData");
             } else if (settings.menu.dashboard) {
                 create_run_statistics_graph();
                 create_run_donut_graph();

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -3161,6 +3161,13 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             return parts.join(" ");
         }
 
+        // returns run card duration class
+        function compare_to_average(duration, average, percent) {
+            const t = parseFloat(percent) / 100;
+            return duration < average * (1 - t) ? 'text-passed' :
+                duration > average * (1 + t) ? 'text-failed' : '';
+        }
+
         //////////////////////////////
         // CUSTOMIZE VIEW FUNCTIONS //
         //////////////////////////////
@@ -4177,11 +4184,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             }
 
             const avg = arr => arr.reduce((a, b) => a + parseFloat(b), 0) / arr.length;
-            const compare_to_average = (duration, avg, percent) => {
-                const t = parseFloat(percent) / 100;
-                return duration < avg * (1 - t) ? 'text-passed' :
-                    duration > avg * (1 + t) ? 'text-failed' : '';
-            };
 
             const overviewCard = (name, stats, duration, status, amount, compares, passed_runs, log_path, log_name, svg, runIndex) => `
         <div class="col-4 overview-card" id="${name}Card${runIndex}">

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -1231,7 +1231,6 @@
         var gridEditMode = false; // used to check how the graphs should be shown when rendered
 
         // global vars for switching between overview and dashboard
-        var overviewGraphs = [];
         var selectedRunSetting = '';
         var selectedTagSetting = '';
 
@@ -3978,6 +3977,56 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             }
         }
 
+      function create_overview_run_donut(run, runIndex, projectName, IsForOverviewStats = true) {
+          let idGraphSubString, passed, failed, skipped;
+
+          if (IsForOverviewStats) {
+              idGraphSubString = "Graph";
+              [passed, failed, skipped] = run.stats;
+          } else {
+              idGraphSubString = "_projectGraph";
+              passed = run.passed;
+              failed = run.failed;
+              skipped = run.skipped;
+          }
+
+          const el = document.getElementById(`${projectName}${idGraphSubString}${runIndex}`);
+
+          if (!el) {
+              console.warn(
+                  `No element with ID ${projectName}${idGraphSubString}${runIndex} found for donut chart creation`
+              );
+              return;
+          }
+
+          if (el.chartInstance) el.chartInstance.destroy();
+          const chartData = {
+              labels: [],
+              datasets: [{
+                  data: [],
+                  backgroundColor: [],
+                  borderColor: [],
+                  hoverOffset: 4
+              }]
+          };
+          const pushIf = (label, value, bg, border) => {
+              if (value > 0) {
+                  chartData.labels.push(label);
+                  chartData.datasets[0].data.push(value);
+                  chartData.datasets[0].backgroundColor.push(bg);
+                  chartData.datasets[0].borderColor.push(border);
+              }
+          };
+          pushIf('passed', passed, passedBackgroundColor, passedBackgroundBorderColor);
+          pushIf('skipped', skipped, skippedBackgroundColor, skippedBackgroundBorderColor);
+          pushIf('failed', failed, failedBackgroundColor, failedBackgroundBorderColor);
+
+          const config = get_graph_config('donut', chartData, 'Run Status');
+          delete config.options.plugins.datalabels;
+          config.options.plugins.legend.display = false;
+
+          el.chartInstance = new Chart(el, config);
+      }
         ///////////////////////////
         // DATA FILTER FUNCTIONS //
         ///////////////////////////
@@ -4152,9 +4201,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
         // function to create overview statistics blocks in the overview section
         function create_overview_statistics_graphs() {
-            for (const g of overviewGraphs) window[g].destroy();
-            overviewGraphs = [];
-
             const data = {};
             for (const run of runs) {
                 var name = '';
@@ -4288,34 +4334,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 }
 
                 runsToShow.forEach((r, runIndex) => {
-                    const el = document.getElementById(`${key}Graph${runIndex}`);
-                    const [passed, failed, skipped] = r.stats;
-                    const chartData = {
-                        labels: [],
-                        datasets: [{
-                            data: [],
-                            backgroundColor: [],
-                            borderColor: [],
-                            hoverOffset: 4
-                        }]
-                    };
-                    const pushIf = (label, value, bg, border) => {
-                        if (value > 0) {
-                            chartData.labels.push(label);
-                            chartData.datasets[0].data.push(value);
-                            chartData.datasets[0].backgroundColor.push(bg);
-                            chartData.datasets[0].borderColor.push(border);
-                        }
-                    };
-                    pushIf('passed', passed, passedBackgroundColor, passedBackgroundBorderColor);
-                    pushIf('failed', failed, failedBackgroundColor, failedBackgroundBorderColor);
-                    pushIf('skipped', skipped, skippedBackgroundColor, skippedBackgroundBorderColor);
-
-                    const config = get_graph_config('donut', chartData, 'Run Status');
-                    delete config.options.plugins.datalabels;
-                    config.options.plugins.legend.display = false;
-                    window[`${key}Graph${runIndex}`] = new Chart(el, config);
-                    overviewGraphs.push(`${key}Graph${runIndex}`);
+                    create_overview_run_donut(r, runIndex, key);
                 });
             });
         }

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -2095,11 +2095,13 @@
             "amount": "Amount of runs that are shown. Only the most recent x runs are shown after applying the other filters.",
             "amountLabel": "Amount of runs that are shown. Only the most recent x runs are shown after applying the other filters.",
             "overviewStatisticsInformation": `This section shows the projects and their associated runs:
-- Duration color indicates performance relative to the average: green if more than x% faster, red if more than x% slower. You can adjust this threshold using the Percentage toggle.
-- Passed runs represent the percentage of runs with zero failures.
+- Overview Statistics show the latest result for each project
+- The additional project bars contain all runs for that project
 - You can define your own projects or groupings by appending '-o path/to/output.xml:project_yourprojectname' when generating results.
-- If runs don't include custom 'project_' tags, they will be grouped by their run name by default. You can change this behavior using the Use Run Tags toggle.
-- The All Runs toggle controls whether only the latest run of each project is shown, or all past runs are displayed in reverse order (newest first). When enabled, you can also filter which project's runs are shown using the selection box.`,
+- If runs don't include custom 'project_' tags, they will be grouped by their run name by default.
+- Choose which project types to show by toggling their respective "Display by" switch.
+- Duration color indicates performance relative to the average: green if more than x% faster, red if more than x% slower. You can adjust this threshold using the Percentage toggle.
+- Passed runs represent the percentage of runs with zero failures.`,
             "runStatisticsGraphPercentages": "Percentages: Displays the distribution of passed, failed, skipped tests per run, where 100% equals all tests combined",
             "runStatisticsGraphAmount": "Amount: Displays the actual number of passed, failed, skipped tests per run",
             "runStatisticsGraphLine": "Line: Displays the same data but over a time axis, useful for spotting failure patterns on specific dates or times",

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -4037,6 +4037,49 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
           });
       }
 
+      // holds rows, each containing 3 run cards, for overview project section
+      function create_project_cards_container(projectName, projectRuns, percent = 20) {
+          const totalRunsAmount = projectRuns.length;
+
+          const passedRunsAmount = projectRuns.filter(run => run.failed === 0).length;
+
+          const passRate = ((passedRunsAmount / totalRunsAmount) * 100).toFixed(2);
+
+          const cardsContainer = document.getElementById(`${projectName}_projectRunCardsContainer`);
+
+          const durations = projectRuns.map(r => r.elapsed_s);
+          const averageDuration = durations.reduce((a,b) => a + parseFloat(b), 0) / durations.length;
+
+          // create section for project in overview if not present
+          if (!cardsContainer) create_project_bar(projectName, projectRuns, totalRunsAmount, passRate);
+
+          const container = document.getElementById(`${projectName}_projectRunCardsContainer`);
+          container.innerHTML = '';
+          const projectRunsToShow = projectRuns.slice().reverse();
+
+          // create cards and charts for each run card
+          let cardCounter = 0;
+          let currentRow;
+
+          projectRunsToShow.forEach((run, idx) => {
+            const runNumber = projectRunsToShow.length - idx;
+            const createdRunCardId = create_project_run_card(run, projectName, idx, runNumber, passRate, percent, averageDuration)
+            const createdRunCard = document.getElementById(createdRunCardId);
+
+            // group 3 cards into row
+            if (cardCounter % 3 === 0) {
+              currentRow = document.createElement('div');
+              currentRow.className = 'row';
+              container.appendChild(currentRow);
+            }
+
+            currentRow.appendChild(createdRunCard);
+            create_overview_run_donut(run, idx, projectName, false);
+            cardCounter++;
+          });
+
+      }
+
       // create a run card that will be displayed within each project section in overview
       function create_project_run_card(run, projectName, runIndex, runNumber, passRate, percent, averageDuration) {
         const stats = [run.passed, run.failed, run.skipped, run.elapsed_s, run.path];

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -3967,254 +3967,224 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             }
         }
 
-      function create_project_overview() {
-        const projectOverviewData = document.getElementById("projectOverviewData");
-        projectOverviewData.innerHTML = "";
+        function create_project_overview() {
+            const projectOverviewData = document.getElementById("projectOverviewData");
+            projectOverviewData.innerHTML = "";
 
-        const isDark = document.documentElement.classList.contains("dark-mode");
-        const svg = isDark ? clockDarkSVG: clockLightSVG;
+            const isDark = document.documentElement.classList.contains("dark-mode");
+            const svg = isDark ? clockDarkSVG: clockLightSVG;
 
-        const projectData = { ...projects_by_name, ...projects_by_tag };
+            const projectData = { ...projects_by_name, ...projects_by_tag };
 
-        // create run cards for each project
-        Object.keys(projectData).sort().forEach(projectName => {
-            create_project_cards_container(projectName, projectData[projectName]);
-        });
+            // create run cards for each project
+            Object.keys(projectData).sort().forEach(projectName => {
+                create_project_cards_container(projectName, projectData[projectName]);
+            });
 
-        // setup collapsables specifically for overview project sections
-        setup_collapsables(projectOverviewData);
-        // set project bar visibility based on switch settings
-        update_projectbar_visibility();
-      }
+            // setup collapsables specifically for overview project sections
+            setup_collapsables(projectOverviewData);
+            // set project bar visibility based on switch settings
+            update_projectbar_visibility();
+        }
 
-      // create project bar (the collapsables below overview statistic) in overview
-      function create_project_bar(projectName, projectRuns, totalRunsAmount, passRate) {
-          const projectOverviewData = document.getElementById("projectOverviewData");
-          const projectCard = `
-          <div class="card mb-3" id="${projectName}_projectCard">
-                <div class="card-header">
-                    <div class="row">
-                        <div class="col-auto align-self-center">
-                            <div class="btn btn-sm collapse-icon" id="collapse${projectName}_projectBody">
-                                ${arrowRight}
-                            </div>
-                        </div>
-                        <div class="col-4">
-                            <h4>${projectName}</h4>
-                            <h6>Total Runs: ${totalRunsAmount} | Passed Runs: ${passRate}%</h6>
-                        </div>
-                        <div class="d-flex flex-wrap align-items-start col align-items-center">
-                            <div class="col-auto">
-                                <div class="btn-group">
-                                    <label class="form-check-label" for="${projectName}_projectDurationPercentage">Percentage</label>
-                                </div>
-                                <div class="btn-group">
-                                    <select class="form-select form-select-sm mt-1" id="${projectName}_projectDurationPercentage">
-                                        ${[10,20,30,40,50,60,70,80,90,100].map(val =>
-                                        `<option value="${val}" ${val === DEFAULT_DURATION_PERCENTAGE ? 'selected' : ''}>${val}</option>`
-                                        ).join('')}
-                                    </select>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="card-body" id="${projectName}_projectBody" hidden="">
-                    <div id="${projectName}_projectRunCardsContainer">
-                    </div>
-                </div>
-            </div>
-          `;
-          projectOverviewData.appendChild(document.createRange().createContextualFragment(projectCard));
-          const projectPercentageSelector = document.getElementById(`${projectName}_projectDurationPercentage`);
-          projectPercentageSelector.addEventListener('change', () => {
-              const newPercent = parseInt(projectPercentageSelector.value, 10);
-              update_duration_comparison_for_project(projectName, projectRuns, newPercent);
-          });
-      }
-
-      // holds rows, each containing 3 run cards, for overview project section
-      function create_project_cards_container(projectName, projectRuns, percent = 20) {
-          const totalRunsAmount = projectRuns.length;
-
-          const passedRunsAmount = projectRuns.filter(run => run.failed === 0).length;
-
-          const passRate = ((passedRunsAmount / totalRunsAmount) * 100).toFixed(2);
-
-          const cardsContainer = document.getElementById(`${projectName}_projectRunCardsContainer`);
-
-          const durations = projectRuns.map(r => r.elapsed_s);
-
-          // create section for project in overview if not present
-          if (!cardsContainer) create_project_bar(projectName, projectRuns, totalRunsAmount, passRate);
-
-          const container = document.getElementById(`${projectName}_projectRunCardsContainer`);
-          container.innerHTML = '';
-          const projectRunsToShow = projectRuns.slice().reverse();
-
-          // create cards and charts for each run card
-          let cardCounter = 0;
-          let currentRow;
-
-          projectRunsToShow.forEach((run, idx) => {
-            const runNumber = projectRunsToShow.length - idx;
-            const createdRunCardId = create_project_run_card(run, projectName, idx, runNumber, passRate, percent, durations)
-            const createdRunCard = document.getElementById(createdRunCardId);
-
-            // group 3 cards into row
-            if (cardCounter % CARDS_PER_ROW === 0) {
-              currentRow = document.createElement('div');
-              currentRow.className = 'row';
-              container.appendChild(currentRow);
-            }
-
-            currentRow.appendChild(createdRunCard);
-            create_overview_run_donut(run, idx, projectName, false);
-            cardCounter++;
-          });
-
-      }
-
-      // create a run card that will be displayed within each project section in overview
-      function create_project_run_card(run, projectName, runIndex, runNumber, passRate, percent, durations) {
-        const avg = arr => arr.reduce((a, b) => a + parseFloat(b), 0) / arr.length;
-
-        const stats = [run.passed, run.failed, run.skipped, run.elapsed_s, run.path];
-
-        const duration = run.elapsed_s;
-        const duration_rounded = Math.round(duration);
-        const durationsForAvg = durations.filter(item => item !== duration);
-        const average = durationsForAvg.length ? avg(durationsForAvg) : duration;
-
-        const status = run.failed > 0 ? 'failed' : run.skipped > 0 ? 'skipped' : 'passed';
-
-        const logPath = use_logs ? transform_file_path(run.path).replaceAll('\\', '\\\\') : '';
-        const logName = use_logs ? 'log.html' : '';
-
-        const isDark = document.documentElement.classList.contains("dark-mode");
-        const svg = isDark ? clockDarkSVG : clockLightSVG;
-
-        const compares = compare_to_average(duration, average, percent);
-
-        const projectRunCardHTML = generate_overview_card_html(
-            projectName,
-            stats,
-            duration_rounded,
-            status,
-            runNumber,
-            compares,
-            passRate,
-            logPath,
-            logName,
-            svg,
-            runIndex,
-            "_project",
-          )
-
-        const existingRunCard = document.getElementById(`${projectName}_projectCard${runIndex}`);
-
-        if (existingRunCard) {
-            // preserves listeners of element
-            existingRunCard.replaceWith(document.createRange().createContextualFragment(projectRunCardHTML));
-        } else {
-            const cardsContainer = document.getElementById(`${projectName}_projectRunCardsContainer`);
-            cardsContainer.appendChild(document.createRange().createContextualFragment(projectRunCardHTML));
-
-            const createdRunCard = document.getElementById(`${projectName}_projectCard${runIndex}`);
-
-            createdRunCard.addEventListener("click", () => {
-                clear_project_filter();
-                set_filter_show_current_project(projectName);
-                update_menu("menuDashboard");
+        // create project bar (the collapsables below overview statistic) in overview
+        function create_project_bar(projectName, projectRuns, totalRunsAmount, passRate) {
+            const projectOverviewData = document.getElementById("projectOverviewData");
+            const projectCard = `
+            <div class="card mb-3" id="${projectName}_projectCard">
+                  <div class="card-header">
+                      <div class="row">
+                          <div class="col-auto align-self-center">
+                              <div class="btn btn-sm collapse-icon" id="collapse${projectName}_projectBody">
+                                  ${arrowRight}
+                              </div>
+                          </div>
+                          <div class="col-4">
+                              <h4>${projectName}</h4>
+                              <h6>Total Runs: ${totalRunsAmount} | Passed Runs: ${passRate}%</h6>
+                          </div>
+                          <div class="d-flex flex-wrap align-items-start col align-items-center">
+                              <div class="col-auto">
+                                  <div class="btn-group">
+                                      <label class="form-check-label" for="${projectName}_projectDurationPercentage">Percentage</label>
+                                  </div>
+                                  <div class="btn-group">
+                                      <select class="form-select form-select-sm mt-1" id="${projectName}_projectDurationPercentage">
+                                          ${[10,20,30,40,50,60,70,80,90,100].map(val =>
+                                          `<option value="${val}" ${val === DEFAULT_DURATION_PERCENTAGE ? 'selected' : ''}>${val}</option>`
+                                          ).join('')}
+                                      </select>
+                                  </div>
+                              </div>
+                          </div>
+                      </div>
+                  </div>
+                  <div class="card-body" id="${projectName}_projectBody" hidden="">
+                      <div id="${projectName}_projectRunCardsContainer">
+                      </div>
+                  </div>
+              </div>
+            `;
+            projectOverviewData.appendChild(document.createRange().createContextualFragment(projectCard));
+            const projectPercentageSelector = document.getElementById(`${projectName}_projectDurationPercentage`);
+            projectPercentageSelector.addEventListener('change', () => {
+                const newPercent = parseInt(projectPercentageSelector.value, 10);
+                update_duration_comparison_for_project(projectName, projectRuns, newPercent);
             });
         }
-        return `${projectName}_projectCard${runIndex}`;
-      }
 
-      function create_overview_run_donut(run, runIndex, projectName, IsForOverviewStats = true) {
-          let idGraphSubString, passed, failed, skipped;
+        // holds rows, each containing 3 run cards, for overview project section
+        function create_project_cards_container(projectName, projectRuns, percent = 20) {
+            const totalRunsAmount = projectRuns.length;
+            const passedRunsAmount = projectRuns.filter(run => run.failed === 0).length;
+            const passRate = ((passedRunsAmount / totalRunsAmount) * 100).toFixed(2);
+            const cardsContainer = document.getElementById(`${projectName}_projectRunCardsContainer`);
+            const durations = projectRuns.map(r => r.elapsed_s);
+            // create section for project in overview if not present
+            if (!cardsContainer) create_project_bar(projectName, projectRuns, totalRunsAmount, passRate);
+            const container = document.getElementById(`${projectName}_projectRunCardsContainer`);
+            container.innerHTML = '';
+            const projectRunsToShow = projectRuns.slice().reverse();
+            // create cards and charts for each run card
+            let cardCounter = 0;
+            let currentRow;
+            projectRunsToShow.forEach((run, idx) => {
+                const runNumber = projectRunsToShow.length - idx;
+                const createdRunCardId = create_project_run_card(run, projectName, idx, runNumber, passRate, percent, durations)
+                const createdRunCard = document.getElementById(createdRunCardId);
+                // group 3 cards into row
+                if (cardCounter % CARDS_PER_ROW === 0) {
+                    currentRow = document.createElement('div');
+                    currentRow.className = 'row';
+                    container.appendChild(currentRow);
+                }
+                currentRow.appendChild(createdRunCard);
+                create_overview_run_donut(run, idx, projectName, false);
+                cardCounter++;
+            });
+        }
 
-          if (IsForOverviewStats) {
-              idGraphSubString = "Graph";
-              [passed, failed, skipped] = run.stats;
-          } else {
-              idGraphSubString = "_projectGraph";
-              passed = run.passed;
-              failed = run.failed;
-              skipped = run.skipped;
-          }
+        // create a run card that will be displayed within each project section in overview
+        function create_project_run_card(run, projectName, runIndex, runNumber, passRate, percent, durations) {
+            const avg = arr => arr.reduce((a, b) => a + parseFloat(b), 0) / arr.length;
 
-          const el = document.getElementById(`${projectName}${idGraphSubString}${runIndex}`);
+            const stats = [run.passed, run.failed, run.skipped, run.elapsed_s, run.path];
+            const duration = run.elapsed_s;
+            const duration_rounded = Math.round(duration);
+            const durationsForAvg = durations.filter(item => item !== duration);
+            const average = durationsForAvg.length ? avg(durationsForAvg) : duration;
+            const status = run.failed > 0 ? 'failed' : run.skipped > 0 ? 'skipped' : 'passed';
+            const logPath = use_logs ? transform_file_path(run.path).replaceAll('\\', '\\\\') : '';
+            const logName = use_logs ? 'log.html' : '';
+            const isDark = document.documentElement.classList.contains("dark-mode");
+            const svg = isDark ? clockDarkSVG : clockLightSVG;
+            const compares = compare_to_average(duration, average, percent);
 
-          if (!el) {
-              console.warn(
-                  `No element with ID ${projectName}${idGraphSubString}${runIndex} found for donut chart creation`
-              );
-              return;
-          }
+            const projectRunCardHTML = generate_overview_card_html(
+                projectName,
+                stats,
+                duration_rounded,
+                status,
+                runNumber,
+                compares,
+                passRate,
+                logPath,
+                logName,
+                svg,
+                runIndex,
+                "_project",
+            )
+            const existingRunCard = document.getElementById(`${projectName}_projectCard${runIndex}`);
+            if (existingRunCard) {
+                // preserves listeners of element
+                existingRunCard.replaceWith(document.createRange().createContextualFragment(projectRunCardHTML));
+            } else {
+                const cardsContainer = document.getElementById(`${projectName}_projectRunCardsContainer`);
+                cardsContainer.appendChild(document.createRange().createContextualFragment(projectRunCardHTML));
+                const createdRunCard = document.getElementById(`${projectName}_projectCard${runIndex}`);
+                createdRunCard.addEventListener("click", () => {
+                    clear_project_filter();
+                    set_filter_show_current_project(projectName);
+                    update_menu("menuDashboard");
+                });
+            }
+            return `${projectName}_projectCard${runIndex}`;
+        }
 
-          if (el.chartInstance) el.chartInstance.destroy();
-          const chartData = {
-              labels: [],
-              datasets: [{
-                  data: [],
-                  backgroundColor: [],
-                  borderColor: [],
-                  hoverOffset: 4
-              }]
-          };
-          const pushIf = (label, value, bg, border) => {
-              if (value > 0) {
-                  chartData.labels.push(label);
-                  chartData.datasets[0].data.push(value);
-                  chartData.datasets[0].backgroundColor.push(bg);
-                  chartData.datasets[0].borderColor.push(border);
-              }
-          };
-          pushIf('passed', passed, passedBackgroundColor, passedBackgroundBorderColor);
-          pushIf('skipped', skipped, skippedBackgroundColor, skippedBackgroundBorderColor);
-          pushIf('failed', failed, failedBackgroundColor, failedBackgroundBorderColor);
-
-          const config = get_graph_config('donut', chartData, 'Run Status');
-          delete config.options.plugins.datalabels;
-          config.options.plugins.legend.display = false;
-
-          el.chartInstance = new Chart(el, config);
-      }
+        function create_overview_run_donut(run, runIndex, projectName, IsForOverviewStats = true) {
+            let idGraphSubString, passed, failed, skipped;
+            if (IsForOverviewStats) {
+                idGraphSubString = "Graph";
+                [passed, failed, skipped] = run.stats;
+            } else {
+                idGraphSubString = "_projectGraph";
+                passed = run.passed;
+                failed = run.failed;
+                skipped = run.skipped;
+            }
+            const el = document.getElementById(`${projectName}${idGraphSubString}${runIndex}`);
+            if (!el) {
+                console.warn(
+                    `No element with ID ${projectName}${idGraphSubString}${runIndex} found for donut chart creation`
+                );
+                return;
+            }
+            if (el.chartInstance) el.chartInstance.destroy();
+            const chartData = {
+                labels: [],
+                datasets: [{
+                    data: [],
+                    backgroundColor: [],
+                    borderColor: [],
+                    hoverOffset: 4
+                }]
+            };
+            const pushIf = (label, value, bg, border) => {
+                if (value > 0) {
+                    chartData.labels.push(label);
+                    chartData.datasets[0].data.push(value);
+                    chartData.datasets[0].backgroundColor.push(bg);
+                    chartData.datasets[0].borderColor.push(border);
+                }
+            };
+            pushIf('passed', passed, passedBackgroundColor, passedBackgroundBorderColor);
+            pushIf('skipped', skipped, skippedBackgroundColor, skippedBackgroundBorderColor);
+            pushIf('failed', failed, failedBackgroundColor, failedBackgroundBorderColor);
+            const config = get_graph_config('donut', chartData, 'Run Status');
+            delete config.options.plugins.datalabels;
+            config.options.plugins.legend.display = false;
+            el.chartInstance = new Chart(el, config);
+        }
 
         // hide project bars based on switch config
         function update_projectbar_visibility() {
             const container = document.getElementById("projectOverviewData");
             if (!container) return;
-
             const bars = container.querySelectorAll('[id$="_projectCard"]');
-
             const tagged = [];
             const untagged = [];
             for (const el of bars) {
-              (el.id.startsWith("project_") ? tagged : untagged).push(el);
+                (el.id.startsWith("project_") ? tagged : untagged).push(el);
             }
-
             const toggleVisibility = (elements, visible) => {
-              for (const el of elements) el.hidden = !visible;
+                for (const el of elements) el.hidden = !visible;
             };
-
             toggleVisibility(tagged, settings.switch.runTags);
             toggleVisibility(untagged, settings.switch.runName);
         }
 
         // prevents regeneration of run cards, just changes class for duration highlight
         function update_duration_comparison_for_project(projectName, projectRuns, percentage) {
-          for (let i = 0; i < projectRuns.length; i++) {
-            const comparesElement = document.getElementById(`${projectName}_projectRunCardCompares${i}`);
-            const duration = document.getElementById(`${projectName}_projectRunCardComparesValue${i}`).getAttribute("value");
-            const durationsForAvg = projectRuns
-                                    .map(r => parseFloat(r.elapsed_s))
-                                    .reverse()
-                                    .filter((_, idx) => idx !== i)
-            const averageDuration = durationsForAvg.reduce((a,b) => a + parseFloat(b), 0) / durationsForAvg.length;
-            comparesElement.className = compare_to_average(duration, averageDuration, percentage);
-          }
+            for (let i = 0; i < projectRuns.length; i++) {
+                const comparesElement = document.getElementById(`${projectName}_projectRunCardCompares${i}`);
+                const duration = document.getElementById(`${projectName}_projectRunCardComparesValue${i}`).getAttribute("value");
+                const durationsForAvg = projectRuns
+                                        .map(r => parseFloat(r.elapsed_s))
+                                        .reverse()
+                                        .filter((_, idx) => idx !== i)
+                const averageDuration = durationsForAvg.reduce((a,b) => a + parseFloat(b), 0) / durationsForAvg.length;
+                comparesElement.className = compare_to_average(duration, averageDuration, percentage);
+            }
         }
 
         ///////////////////////////
@@ -4387,16 +4357,13 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         function prepare_projects_grouped_data() {
             for (const run of runs) {
                 const tags = run.tags.split(",");
-                // in case multiple project_ tags are set
                 const project_tags = tags.filter(tag => tag.toLowerCase().startsWith("project_"));
-
                 for (const project of project_tags) {
                     if (!projects_by_tag[project]) {
                         projects_by_tag[project] = [];
                     }
                     projects_by_tag[project].push(run);
                 }
-
                 if (!projects_by_name[run.name]) {
                     projects_by_name[run.name] = [];
                 }
@@ -4404,9 +4371,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             }
             areGroupedProjectsPrepared = true;
             create_project_overview();
-            return;
         }
-
 
         //////////////////////////////////////
         // GRAPH & TABLE CREATION FUNCTIONS //
@@ -4455,12 +4420,10 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                     const [passed, failed, skipped, duration, rawPath] = r.stats;
                     const path = transform_file_path(rawPath).replaceAll('\\', '\\\\');
                     const runNumber = runList.length - runIndex;
-
                     const durationsForAvg = runList
                                             .map(x => x.duration)
                                             .filter(item => item !== duration);
                     const average = durationsForAvg.length ? avg(durationsForAvg) : duration;
-
                     const compares = compare_to_average(duration, average, overviewDurationPercentage);
                     const rounded_duration = Math.round(duration);
                     const passedRuns = (runList.reduce((a, b) => a + b.passed_run, 0) / runList.length * 100).toFixed(2);
@@ -4471,7 +4434,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                     if (cardCounter % CARDS_PER_ROW === 0) {
                         overviewHTML += '<div class="row">';
                     }
-
                     overviewHTML += generate_overview_card_html(
                         key,
                         r.stats,
@@ -4485,9 +4447,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                         svg,
                         runIndex
                     );
-
                     cardCounter++;
-
                     if (cardCounter % CARDS_PER_ROW === 0) {
                         overviewHTML += '</div>';
                     }
@@ -4497,14 +4457,11 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             if (cardCounter % CARDS_PER_ROW !== 0) {
                 overviewHTML += '</div>';
             }
-
             document.getElementById("gridOverview").innerHTML = overviewHTML;
-
             // attach click listeners (from original logic)
             keys.forEach(key => {
                 const runList = data[key].runs.slice().reverse();
                 const runsToShow = [runList[0]];
-
                 runsToShow.forEach((r, runIndex) => {
                     const cardEl = document.getElementById(`${key}Card${runIndex}`);
                     if (cardEl) {
@@ -4521,7 +4478,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             keys.forEach(key => {
                 const runList = data[key].runs.slice().reverse();
                 const runsToShow = [runList[0]];
-
                 runsToShow.forEach((r, runIndex) => {
                     create_overview_run_donut(r, runIndex, key);
                 });

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -2817,9 +2817,9 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             document.getElementById("alertContainer").innerHTML = ""
         }
 
-        // function to setup all collapse buttons and icons
-        function setup_collapsables() {
-            document.querySelectorAll(".collapse-icon").forEach(icon => {
+        // function to setup collapse buttons and icons
+        function setup_collapsables(elementToSearch = document) {
+            elementToSearch.querySelectorAll(".collapse-icon").forEach(icon => {
                 const sectionId = icon.id.replace("collapse", "");
                 const update_icon = () => {
                     const section = document.getElementById(sectionId);

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -502,15 +502,6 @@
                             <h4 id="overviewTitle"></h4>
                         </div>
                         <div class="d-flex flex-wrap align-items-start col align-items-center">
-                            <div class="col-auto">
-                                <div class="btn-group">
-                                    <label class="form-check-label" for="switchShowAllRuns">Display All Runs</label>
-                                </div>
-                                <div class="btn-group form-switch ms-1">
-                                    <input class="form-check-input" type="checkbox" role="switch"
-                                        id="switchShowAllRuns" />
-                                </div>
-                            </div>
                             <div class="col-auto" id="overviewName" hidden>
                                 <div class="btn-group">
                                     <label class="form-check-label" for="overviewSelectName">Name</label>
@@ -521,7 +512,9 @@
                             </div>
                             <div class="col-auto">
                                 <div class="btn-group">
-                                    <label class="form-check-label ms-2" for="switchRunTags">Use Run Tags</label>
+                            <div class="col-auto">
+                                <div class="btn-group">
+                                    <label class="form-check-label ms-2" for="switchRunTags">Display by Tag</label>
                                 </div>
                                 <div class="btn-group form-switch ms-1">
                                     <input class="form-check-input" type="checkbox" role="switch" id="switchRunTags" />
@@ -2375,7 +2368,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         // settings var
         var settings = {
             switch: {
-                showAllRuns: false,
                 runTags: false,
                 suitePathsSuiteSection: false,
                 suitePathsTestSection: false,
@@ -3460,20 +3452,10 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
         // function to setup eventlisteners for filter buttons
         function setup_sections_filters() {
-            update_switch_local_storage("switch.showAllRuns", settings.switch.showAllRuns, true)
-            document.getElementById("overviewName").hidden = !settings.switch.showAllRuns; // set the initial state of the overview name select
-            document.getElementById("switchShowAllRuns").addEventListener("click", function () {
-                settings.switch.showAllRuns = !settings.switch.showAllRuns
-                document.getElementById("overviewName").hidden = !settings.switch.showAllRuns;
-                update_switch_local_storage("switch.showAllRuns", settings.switch.showAllRuns);
-                create_overview_statistics_graphs();
-            });
             update_switch_local_storage("switch.runTags", settings.switch.runTags, true);
-            setup_names_in_overview_select(); // update the names in the select to make sure the runTags option is taken into account
             document.getElementById("switchRunTags").addEventListener("click", function () {
                 settings.switch.runTags = !settings.switch.runTags
                 update_switch_local_storage("switch.runTags", settings.switch.runTags);
-                setup_names_in_overview_select();
                 create_overview_statistics_graphs();
                 create_project_overview();
             });
@@ -3838,31 +3820,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             } else {
                 document.getElementById("runTagFilter").hidden = true
             }
-        }
-
-        function setup_names_in_overview_select() {
-            const overviewSelectName = document.getElementById("overviewSelectName")
-            const names = new Set()
-            for (const run of runs) {
-                var name = '';
-                if (settings.switch.runTags) {
-                    const tags = run.tags.split(",")
-                    var foundTag = false;
-                    for (const tag of tags) {
-                        if (tag.startsWith('project_')) {
-                            name = tag;
-                            foundTag = true;
-                            break
-                        }
-                    }
-                    if (!foundTag) name = run.name;
-                } else {
-                    name = run.name;
-                }
-                names.add(name)
-            }
-            overviewSelectName.innerHTML = ""
-            names.forEach(item => overviewSelectName.options.add(new Option(item, item)));
         }
 
         // function to update the available runs in the selects
@@ -4454,14 +4411,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
             keys.forEach(key => {
                 const runList = [...data[key].runs].reverse(); // newest first
-                const runsToShow = settings.switch.showAllRuns ? runList : [runList[0]];
-
-                const selectedName = settings.switch.showAllRuns
-                    ? document.getElementById("overviewSelectName").value
-                    : null;
-                if (settings.switch.showAllRuns && selectedName && selectedName !== key) {
-                    return;
-                }
+                const runsToShow = [runList[0]];
 
                 runsToShow.forEach((r, runIndex) => {
                     const [passed, failed, skipped, duration, rawPath] = r.stats;
@@ -4513,14 +4463,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             // attach click listeners (from original logic)
             keys.forEach(key => {
                 const runList = data[key].runs.slice().reverse();
-                const runsToShow = settings.switch.showAllRuns ? runList : [runList[0]];
-                const selectedName = settings.switch.showAllRuns
-                    ? document.getElementById("overviewSelectName").value
-                    : null;
-
-                if (settings.switch.showAllRuns && selectedName && selectedName !== key) {
-                    return;
-                }
+                const runsToShow = [runList[0]];
 
                 runsToShow.forEach((r, runIndex) => {
                     const cardEl = document.getElementById(`${key}Card${runIndex}`);
@@ -4537,14 +4480,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             // build charts
             keys.forEach(key => {
                 const runList = data[key].runs.slice().reverse();
-                const runsToShow = settings.switch.showAllRuns ? runList : [runList[0]];
-                const selectedName = settings.switch.showAllRuns
-                    ? document.getElementById("overviewSelectName").value
-                    : null;
-
-                if (settings.switch.showAllRuns && selectedName && selectedName !== key) {
-                    return;
-                }
+                const runsToShow = [runList[0]];
 
                 runsToShow.forEach((r, runIndex) => {
                     create_overview_run_donut(r, runIndex, key);
@@ -7620,7 +7556,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             document.getElementById("compareTitle").innerHTML = `Compare Statistics ${message}`;
             document.getElementById("tablesTitle").innerHTML = `Table Statistics (${runAmount}) ${message}`;
             // update filters based on data
-            setup_names_in_overview_select();
             setup_runs_in_compare_selects();
             setup_suites_in_suite_select();
             setup_suites_in_test_select();

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -3471,7 +3471,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 ensureOneOn("runTags", "runName", switchRunName);
                 update_switch_local_storage("switch.runName", settings.switch.runName);
                 create_overview_statistics_graphs();
-                create_project_overview();
+                update_projectbar_visibility();
             });
             switchRunName.addEventListener("click", function () {
                 settings.switch.runName = !settings.switch.runName
@@ -3479,7 +3479,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 ensureOneOn("runName", "runTags", switchRunTags);
                 update_switch_local_storage("switch.runTags", settings.switch.runTags);
                 create_overview_statistics_graphs();
-                create_project_overview();
+                update_projectbar_visibility();
             });
             document.getElementById("overviewSelectName").addEventListener("change", function () {
                 create_overview_statistics_graphs();
@@ -3985,13 +3985,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         const isDark = document.documentElement.classList.contains("dark-mode");
         const svg = isDark ? clockDarkSVG: clockLightSVG;
 
-        const { runName, runTags } = settings.switch;
-        const projectData = runName && runTags
-            ? { ...projects_by_name, ...projects_by_tag }
-            : runName
-            ? projects_by_name
-            : projects_by_tag;
-
+        const projectData = { ...projects_by_name, ...projects_by_tag };
 
         // create run cards for each project
         Object.keys(projectData).sort().forEach(projectName => {
@@ -4000,6 +3994,8 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
         // setup collapsables specifically for overview project sections
         setup_collapsables(projectOverviewData);
+        // set project bar visibility based on switch settings
+        update_projectbar_visibility();
       }
 
       // create project bar (the collapsables below overview statistic) in overview
@@ -4198,6 +4194,27 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
           el.chartInstance = new Chart(el, config);
       }
+
+        // hide project bars based on switch config
+        function update_projectbar_visibility() {
+            const container = document.getElementById("projectOverviewData");
+            if (!container) return;
+
+            const bars = container.querySelectorAll('[id$="_projectCard"]');
+
+            const tagged = [];
+            const untagged = [];
+            for (const el of bars) {
+              (el.id.startsWith("project_") ? tagged : untagged).push(el);
+            }
+
+            const toggleVisibility = (elements, visible) => {
+              for (const el of elements) el.hidden = !visible;
+            };
+
+            toggleVisibility(tagged, settings.switch.runTags);
+            toggleVisibility(untagged, settings.switch.runName);
+        }
 
         // prevents regeneration of run cards, just changes class for duration highlight
         function update_duration_comparison_for_project(projectName, projectRuns, percentage) {

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -3991,11 +3991,11 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         function create_project_bar(projectName, projectRuns, totalRunsAmount, passRate) {
             const projectOverviewData = document.getElementById("projectOverviewData");
             const projectCard = `
-            <div class="card mb-3" id="${projectName}_projectCard">
+            <div class="card mb-3" id="${projectName}Card">
                   <div class="card-header">
                       <div class="row">
                           <div class="col-auto align-self-center">
-                              <div class="btn btn-sm collapse-icon" id="collapse${projectName}_projectBody">
+                              <div class="btn btn-sm collapse-icon" id="collapse${projectName}Body">
                                   ${arrowRight}
                               </div>
                           </div>
@@ -4006,10 +4006,10 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                           <div class="d-flex flex-wrap align-items-start col align-items-center">
                               <div class="col-auto">
                                   <div class="btn-group">
-                                      <label class="form-check-label" for="${projectName}_projectDurationPercentage">Percentage</label>
+                                      <label class="form-check-label" for="${projectName}DurationPercentage">Percentage</label>
                                   </div>
                                   <div class="btn-group">
-                                      <select class="form-select form-select-sm mt-1" id="${projectName}_projectDurationPercentage">
+                                      <select class="form-select form-select-sm mt-1" id="${projectName}DurationPercentage">
                                           ${[10,20,30,40,50,60,70,80,90,100].map(val =>
                                           `<option value="${val}" ${val === DEFAULT_DURATION_PERCENTAGE ? 'selected' : ''}>${val}</option>`
                                           ).join('')}
@@ -4019,14 +4019,14 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                           </div>
                       </div>
                   </div>
-                  <div class="card-body" id="${projectName}_projectBody" hidden="">
-                      <div id="${projectName}_projectRunCardsContainer">
+                  <div class="card-body" id="${projectName}Body" hidden="">
+                      <div id="${projectName}RunCardsContainer">
                       </div>
                   </div>
               </div>
             `;
             projectOverviewData.appendChild(document.createRange().createContextualFragment(projectCard));
-            const projectPercentageSelector = document.getElementById(`${projectName}_projectDurationPercentage`);
+            const projectPercentageSelector = document.getElementById(`${projectName}DurationPercentage`);
             projectPercentageSelector.addEventListener('change', () => {
                 const newPercent = parseInt(projectPercentageSelector.value, 10);
                 update_duration_comparison_for_project(projectName, projectRuns, newPercent);
@@ -4038,11 +4038,11 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             const totalRunsAmount = projectRuns.length;
             const passedRunsAmount = projectRuns.filter(run => run.failed === 0).length;
             const passRate = ((passedRunsAmount / totalRunsAmount) * 100).toFixed(2);
-            const cardsContainer = document.getElementById(`${projectName}_projectRunCardsContainer`);
+            const cardsContainer = document.getElementById(`${projectName}RunCardsContainer`);
             const durations = projectRuns.map(r => r.elapsed_s);
             // create section for project in overview if not present
             if (!cardsContainer) create_project_bar(projectName, projectRuns, totalRunsAmount, passRate);
-            const container = document.getElementById(`${projectName}_projectRunCardsContainer`);
+            const container = document.getElementById(`${projectName}RunCardsContainer`);
             container.innerHTML = '';
             const projectRunsToShow = projectRuns.slice().reverse();
             // create cards and charts for each run card
@@ -4059,7 +4059,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                     container.appendChild(currentRow);
                 }
                 currentRow.appendChild(createdRunCard);
-                create_overview_run_donut(run, idx, projectName, false);
+                create_overview_run_donut(run, idx, projectName);
                 cardCounter++;
             });
         }
@@ -4092,40 +4092,41 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 logName,
                 svg,
                 runIndex,
-                "_project",
             )
-            const existingRunCard = document.getElementById(`${projectName}_projectCard${runIndex}`);
+            const existingRunCard = document.getElementById(`${projectName}Card${runIndex}`);
             if (existingRunCard) {
                 // preserves listeners of element
                 existingRunCard.replaceWith(document.createRange().createContextualFragment(projectRunCardHTML));
             } else {
-                const cardsContainer = document.getElementById(`${projectName}_projectRunCardsContainer`);
+                const cardsContainer = document.getElementById(`${projectName}RunCardsContainer`);
                 cardsContainer.appendChild(document.createRange().createContextualFragment(projectRunCardHTML));
-                const createdRunCard = document.getElementById(`${projectName}_projectCard${runIndex}`);
+                const createdRunCard = document.getElementById(`${projectName}Card${runIndex}`);
                 createdRunCard.addEventListener("click", () => {
                     clear_project_filter();
                     set_filter_show_current_project(projectName);
                     update_menu("menuDashboard");
                 });
             }
-            return `${projectName}_projectCard${runIndex}`;
+            return `${projectName}Card${runIndex}`;
         }
 
-        function create_overview_run_donut(run, runIndex, projectName, IsForOverviewStats = true) {
-            let idGraphSubString, passed, failed, skipped;
-            if (IsForOverviewStats) {
-                idGraphSubString = "Graph";
+        function create_overview_run_donut(run, chartElementPostfix, projectName) {
+            let passed, failed, skipped;
+            const idGraphSubString = "Graph";
+            // when called for overview statistics
+            if (run.stats) {
                 [passed, failed, skipped] = run.stats;
-            } else {
-                idGraphSubString = "_projectGraph";
+            }
+            // when called for projects section in overview
+            else {
                 passed = run.passed;
                 failed = run.failed;
                 skipped = run.skipped;
             }
-            const el = document.getElementById(`${projectName}${idGraphSubString}${runIndex}`);
+            const el = document.getElementById(`${projectName}${idGraphSubString}${chartElementPostfix}`);
             if (!el) {
                 console.warn(
-                    `No element with ID ${projectName}${idGraphSubString}${runIndex} found for donut chart creation`
+                    `No element with ID ${projectName}${idGraphSubString}${chartElementPostfix} found for donut chart creation`
                 );
                 return;
             }
@@ -4160,7 +4161,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         function update_projectbar_visibility() {
             const container = document.getElementById("projectOverviewData");
             if (!container) return;
-            const bars = container.querySelectorAll('[id$="_projectCard"]');
+            const bars = container.querySelectorAll('[id$="Card"]');
             const tagged = [];
             const untagged = [];
             for (const el of bars) {
@@ -4176,8 +4177,8 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         // prevents regeneration of run cards, just changes class for duration highlight
         function update_duration_comparison_for_project(projectName, projectRuns, percentage) {
             for (let i = 0; i < projectRuns.length; i++) {
-                const comparesElement = document.getElementById(`${projectName}_projectRunCardCompares${i}`);
-                const duration = document.getElementById(`${projectName}_projectRunCardComparesValue${i}`).getAttribute("value");
+                const comparesElement = document.getElementById(`${projectName}RunCardCompares${i}`);
+                const duration = document.getElementById(`${projectName}RunCardComparesValue${i}`).getAttribute("value");
                 const durationsForAvg = projectRuns
                                         .map(r => parseFloat(r.elapsed_s))
                                         .reverse()
@@ -4411,84 +4412,71 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             document.getElementById("overviewTitle").innerHTML = `Overview Statistics <h6>showing ${Object.keys(runs).length} runs in ${keys.length} projects</h6`;
 
             let cardCounter = 0;
+            const idPostfix = "_OverviewStatistics"; // can be a set postfix because it is always unique with the name in this code
 
             keys.forEach(key => {
                 const runList = [...data[key].runs].reverse(); // newest first
-                const runsToShow = [runList[0]];
+                const r = runList[0];
+                const [passed, failed, skipped, duration, rawPath] = r.stats;
+                const path = transform_file_path(rawPath).replaceAll('\\', '\\\\');
+                const runNumber = runList.length;
+                const durationsForAvg = runList
+                    .map(x => x.duration)
+                    .filter(item => item !== duration);
+                const average = durationsForAvg.length ? avg(durationsForAvg) : duration;
+                const compares = compare_to_average(duration, average, overviewDurationPercentage);
+                const rounded_duration = Math.round(duration);
+                const passedRuns = (runList.reduce((a, b) => a + b.passed_run, 0) / runList.length * 100).toFixed(2);
+                const status = failed > 0 ? 'failed' : skipped > 0 ? 'skipped' : 'passed';
+                const log_path = use_logs ? path : '';
+                const log_name = use_logs ? 'log.html' : '';
 
-                runsToShow.forEach((r, runIndex) => {
-                    const [passed, failed, skipped, duration, rawPath] = r.stats;
-                    const path = transform_file_path(rawPath).replaceAll('\\', '\\\\');
-                    const runNumber = runList.length - runIndex;
-                    const durationsForAvg = runList
-                                            .map(x => x.duration)
-                                            .filter(item => item !== duration);
-                    const average = durationsForAvg.length ? avg(durationsForAvg) : duration;
-                    const compares = compare_to_average(duration, average, overviewDurationPercentage);
-                    const rounded_duration = Math.round(duration);
-                    const passedRuns = (runList.reduce((a, b) => a + b.passed_run, 0) / runList.length * 100).toFixed(2);
-                    const status = failed > 0 ? 'failed' : skipped > 0 ? 'skipped' : 'passed';
-                    const log_path = use_logs ? path : '';
-                    const log_name = use_logs ? 'log.html' : '';
-
-                    if (cardCounter % CARDS_PER_ROW === 0) {
-                        overviewHTML += '<div class="row">';
-                    }
-                    overviewHTML += generate_overview_card_html(
-                        key,
-                        r.stats,
-                        rounded_duration,
-                        status,
-                        runNumber,
-                        compares,
-                        passedRuns,
-                        log_path,
-                        log_name,
-                        svg,
-                        runIndex
-                    );
-                    cardCounter++;
-                    if (cardCounter % CARDS_PER_ROW === 0) {
-                        overviewHTML += '</div>';
-                    }
-                });
+                if (cardCounter % CARDS_PER_ROW === 0) {
+                    overviewHTML += '<div class="row">';
+                }
+                overviewHTML += generate_overview_card_html(
+                    key,
+                    r.stats,
+                    rounded_duration,
+                    status,
+                    runNumber,
+                    compares,
+                    passedRuns,
+                    log_path,
+                    log_name,
+                    svg,
+                    idPostfix
+                );
+                cardCounter++;
+                if (cardCounter % CARDS_PER_ROW === 0) {
+                    overviewHTML += '</div>';
+                }
             });
 
             if (cardCounter % CARDS_PER_ROW !== 0) {
                 overviewHTML += '</div>';
             }
             document.getElementById("gridOverview").innerHTML = overviewHTML;
-            // attach click listeners (from original logic)
             keys.forEach(key => {
                 const runList = data[key].runs.slice().reverse();
-                const runsToShow = [runList[0]];
-                runsToShow.forEach((r, runIndex) => {
-                    const cardEl = document.getElementById(`${key}Card${runIndex}`);
-                    if (cardEl) {
-                        cardEl.addEventListener("click", () => {
-                            clear_project_filter();
-                            set_filter_show_current_project(key);
-                            update_menu("menuDashboard");
-                        });
-                    }
-                });
-            });
-
-            // build charts
-            keys.forEach(key => {
-                const runList = data[key].runs.slice().reverse();
-                const runsToShow = [runList[0]];
-                runsToShow.forEach((r, runIndex) => {
-                    create_overview_run_donut(r, runIndex, key);
-                });
+                const r = runList[0];
+                const cardEl = document.getElementById(`${key}Card${idPostfix}`);
+                if (cardEl) {
+                    // build charts
+                    create_overview_run_donut(r, "_OverviewStatistics", key);
+                    // attach click listener
+                    cardEl.addEventListener("click", () => {
+                        clear_project_filter();
+                        set_filter_show_current_project(key);
+                        update_menu("menuDashboard");
+                    });
+                }
             });
         }
 
-        // ProjectNamePostfix is for differentiating overview statistic and project specific statistics
-        // since the project specific statistics are differentiated by adding project_ after projectName to the id
-        function generate_overview_card_html(projectName, stats, rounded_duration, status, runNumber, compares, passed_runs, log_path, log_name, svg, runIndex, projectNamePostfix = "") {
+        function generate_overview_card_html(projectName, stats, rounded_duration, status, runNumber, compares, passed_runs, log_path, log_name, svg, idPostfix) {
             return `
-            <div class="col-4 overview-card" id="${projectName}${projectNamePostfix}Card${runIndex}">
+            <div class="col-4 overview-card" id="${projectName}Card${idPostfix}">
                 <div class="card border-3 border-${status}">
                     <div class="card-body">
                         <div class="row">
@@ -4497,7 +4485,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                         </div>
                         <div class="row">
                             <div class="col-4 overview-canvas">
-                                <canvas id="${projectName}${projectNamePostfix}Graph${runIndex}"></canvas>
+                                <canvas id="${projectName}Graph${idPostfix}"></canvas>
                             </div>
                             <div class="col-3 d-flex align-items-center">
                                 <div>
@@ -4508,9 +4496,9 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                             </div>
                             <div class="col-5 d-flex align-items-center" style="overflow:auto;">
                                 <div>
-                                    <div class="${compares}" id="${projectName}${projectNamePostfix}RunCardCompares${runIndex}">
+                                    <div class="${compares}" id="${projectName}RunCardCompares${idPostfix}">
                                         ${svg}
-                                        <i id="${projectName}${projectNamePostfix}RunCardComparesValue${runIndex}" value="${rounded_duration}">
+                                        <i id="${projectName}RunCardComparesValue${idPostfix}" value="${rounded_duration}">
                                             ${rounded_duration}s
                                         </i>
                                     </div>

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -1153,7 +1153,7 @@
 
         // UI defaults
         const CARDS_PER_ROW = 3;
-
+        const DEFAULT_DURATION_PERCENTAGE = 20;
 
         // base bar config
         const barConfig = {
@@ -4027,16 +4027,9 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                                 </div>
                                 <div class="btn-group">
                                     <select class="form-select form-select-sm mt-1" id="${projectName}_projectDurationPercentage">
-                                        <option value="10">10</option>
-                                        <option value="20" selected="">20</option>
-                                        <option value="30">30</option>
-                                        <option value="40">40</option>
-                                        <option value="50">50</option>
-                                        <option value="60">60</option>
-                                        <option value="70">70</option>
-                                        <option value="80">80</option>
-                                        <option value="90">90</option>
-                                        <option value="100">100</option>
+                                        ${[10,20,30,40,50,60,70,80,90,100].map(val =>
+                                        `<option value="${val}" ${val === DEFAULT_DURATION_PERCENTAGE ? 'selected' : ''}>${val}</option>`
+                                        ).join('')}
                                     </select>
                                 </div>
                             </div>

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -2531,6 +2531,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                         ".move-down-table": moveDownLightSVG,
                         ".move-up-section": moveUpLightSVG,
                         ".move-down-section": moveDownLightSVG,
+                        ".clock-icon": clockLightSVG,
                     }
                 };
                 for (const [id, svg] of Object.entries(svgMap.ids)) {
@@ -2593,6 +2594,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                         ".move-down-table": moveDownDarkSVG,
                         ".move-up-section": moveUpDarkSVG,
                         ".move-down-section": moveDownDarkSVG,
+                        ".clock-icon": clockDarkSVG,
                     }
                 };
                 for (const [id, svg] of Object.entries(svgMap.ids)) {
@@ -4491,7 +4493,9 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                             <div class="col-5 d-flex align-items-center" style="overflow:auto;">
                                 <div>
                                     <div class="${compares}" id="${projectName}RunCardCompares${idPostfix}">
-                                        ${svg}
+                                        <span class="clock-icon">
+                                            ${svg}
+                                        </span>
                                         <i id="${projectName}RunCardComparesValue${idPostfix}" value="${rounded_duration}">
                                             ${rounded_duration}s
                                         </i>

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -1206,6 +1206,11 @@
         const tests = decode_and_decompress("placeholder_tests").sort((a, b) => new Date(a.run_start).getTime() - new Date(b.run_start).getTime());
         const keywords = decode_and_decompress("placeholder_keywords").sort((a, b) => new Date(a.run_start).getTime() - new Date(b.run_start).getTime());
 
+        // populated by prepare_projects_grouped_data()
+        const projects_by_tag = {};
+        const projects_by_name = {};
+        let areGroupedProjectsPrepared = false; 
+
         function decode_and_decompress(base64Str) {
             const compressedData = Uint8Array.from(atob(base64Str), c => c.charCodeAt(0));
             const decompressedData = pako.inflate(compressedData, { to: 'string' });
@@ -3992,7 +3997,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         const isDark = document.documentElement.classList.contains("dark-mode");
         const svg = isDark ? clockDarkSVG: clockLightSVG;
 
-        const projectData = settings.switch.runTags ? projects['by_tag'] : projects['by_name'];
+        const projectData = settings.switch.runTags ? projects_by_tag : projects_by_name;
 
         // create run cards for each project
         Object.keys(projectData).sort().forEach(projectName => {
@@ -4376,6 +4381,29 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             } else {
                 selectedRunSetting = projectName;
             }
+            return;
+        }
+
+        function prepare_projects_grouped_data() {
+            for (const run of runs) {
+                const tags = run.tags.split(",");
+                // in case multiple project_ tags are set
+                const project_tags = tags.filter(tag => tag.toLowerCase().startsWith("project_"));
+
+                for (const project of project_tags) {
+                    if (!projects_by_tag[project]) {
+                        projects_by_tag[project] = [];
+                    }
+                    projects_by_tag[project].push(run);
+                }
+
+                if (!projects_by_name[run.name]) {
+                    projects_by_name[run.name] = [];
+                }
+                projects_by_name[run.name].push(run);
+            }
+            areGroupedProjectsPrepared = true;
+            create_project_overview();
             return;
         }
 
@@ -7435,6 +7463,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 document.getElementById(id).classList.toggle("active", id === item);
                 document.getElementById("customizeLayout").hidden = item == "menuOverview";
             });
+            if (item === "menuOverview" && !areGroupedProjectsPrepared) prepare_projects_grouped_data();
             document.getElementById("projectOverview").hidden = item !== "menuOverview";
             setup_data_and_graphs(true);
         }
@@ -7604,7 +7633,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         function setup_dasbhoard_graphs() {
             if (settings.menu.overview) {
                 create_overview_statistics_graphs();
-                create_project_overview();
             } else if (settings.menu.dashboard) {
                 create_run_statistics_graph();
                 create_run_donut_graph();

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -4223,13 +4223,13 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
         // prevents regeneration of run cards, just changes class for duration highlight
         function update_duration_comparison_for_project(projectName, projectRuns, percentage) {
-
           for (let i = 0; i < projectRuns.length; i++) {
             const comparesElement = document.getElementById(`${projectName}_projectRunCardCompares${i}`);
             const duration = document.getElementById(`${projectName}_projectRunCardComparesValue${i}`).getAttribute("value");
             const durationsForAvg = projectRuns
-                                    .map(r => r.elapsed_s)
-                                    .filter(item => item !== duration);
+                                    .map(r => parseFloat(r.elapsed_s))
+                                    .reverse()
+                                    .filter((_, idx) => idx !== i)
             const averageDuration = durationsForAvg.reduce((a,b) => a + parseFloat(b), 0) / durationsForAvg.length;
             comparesElement.className = compare_to_average(duration, averageDuration, percentage);
           }

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -4037,6 +4037,56 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
           });
       }
 
+      // create a run card that will be displayed within each project section in overview
+      function create_project_run_card(run, projectName, runIndex, runNumber, passRate, percent, averageDuration) {
+        const stats = [run.passed, run.failed, run.skipped, run.elapsed_s, run.path];
+        const duration = run.elapsed_s;
+        const duration_rounded = Math.round(duration);
+        const status = run.failed > 0 ? 'failed' : run.skipped > 0 ? 'skipped' : 'passed';
+
+        const logPath = use_logs ? transform_file_path(run.path).replaceAll('\\', '\\\\') : '';
+        const logName = use_logs ? 'log.html' : '';
+
+        const isDark = document.documentElement.classList.contains("dark-mode");
+        const svg = isDark ? clockDarkSVG : clockLightSVG;
+
+        const compares = compare_to_average(duration, averageDuration, percent);
+
+        const projectRunCardHTML = generate_overview_card_html(
+            projectName,
+            stats,
+            duration_rounded,
+            status,
+            runNumber,
+            compares,
+            passRate,
+            logPath,
+            logName,
+            svg,
+            runIndex,
+            "_project",
+          )
+
+        const existingRunCard = document.getElementById(`${projectName}_projectCard${runIndex}`);
+
+        if (existingRunCard) {
+            // preserves listeners of element
+            existingRunCard.replaceWith(document.createRange().createContextualFragment(projectRunCardHTML));
+        } else {
+            const cardsContainer = document.getElementById(`${projectName}_projectRunCardsContainer`);
+            cardsContainer.appendChild(document.createRange().createContextualFragment(projectRunCardHTML));
+
+            const createdRunCard = document.getElementById(`${projectName}_projectCard${runIndex}`);
+
+            createdRunCard.addEventListener("click", () => {
+                clear_project_filter();
+                set_filter_show_current_project(projectName);
+                update_menu("menuDashboard");
+            });
+        }
+        return `${projectName}_projectCard${runIndex}`;
+      }
+
       function create_overview_run_donut(run, runIndex, projectName, IsForOverviewStats = true) {
           let idGraphSubString, passed, failed, skipped;
 

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -1151,6 +1151,10 @@
         const greyBackgroundColor = "rgba(33, 37, 41, 0.7)";
         const graphFontSize = 12;
 
+        // UI defaults
+        const CARDS_PER_ROW = 3;
+
+
         // base bar config
         const barConfig = {
             borderSkipped: false,
@@ -4082,7 +4086,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             const createdRunCard = document.getElementById(createdRunCardId);
 
             // group 3 cards into row
-            if (cardCounter % 3 === 0) {
+            if (cardCounter % CARDS_PER_ROW === 0) {
               currentRow = document.createElement('div');
               currentRow.className = 'row';
               container.appendChild(currentRow);
@@ -4488,7 +4492,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                     const log_path = use_logs ? path : '';
                     const log_name = use_logs ? 'log.html' : '';
 
-                    if (cardCounter % 3 === 0) {
+                    if (cardCounter % CARDS_PER_ROW === 0) {
                         overviewHTML += '<div class="row">';
                     }
 
@@ -4508,13 +4512,13 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
                     cardCounter++;
 
-                    if (cardCounter % 3 === 0) {
+                    if (cardCounter % CARDS_PER_ROW === 0) {
                         overviewHTML += '</div>';
                     }
                 });
             });
 
-            if (cardCounter % 3 !== 0) {
+            if (cardCounter % CARDS_PER_ROW !== 0) {
                 overviewHTML += '</div>';
             }
 

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -3970,17 +3970,11 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         function create_project_overview() {
             const projectOverviewData = document.getElementById("projectOverviewData");
             projectOverviewData.innerHTML = "";
-
-            const isDark = document.documentElement.classList.contains("dark-mode");
-            const svg = isDark ? clockDarkSVG: clockLightSVG;
-
             const projectData = { ...projects_by_name, ...projects_by_tag };
-
             // create run cards for each project
             Object.keys(projectData).sort().forEach(projectName => {
                 create_project_cards_container(projectName, projectData[projectName]);
             });
-
             // setup collapsables specifically for overview project sections
             setup_collapsables(projectOverviewData);
             // set project bar visibility based on switch settings

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -3467,23 +3467,15 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         function setup_sections_filters() {
             update_switch_local_storage("switch.runTags", settings.switch.runTags, true);
             update_switch_local_storage("switch.runName", settings.switch.runName, true);
-
-            const switchRunTags = document.getElementById("switchRunTags");
-            const switchRunName = document.getElementById("switchRunName");
-
-            switchRunTags.addEventListener("click", function () {
+            document.getElementById("switchRunTags").addEventListener("click", function () {
                 settings.switch.runTags = !settings.switch.runTags
                 update_switch_local_storage("switch.runTags", settings.switch.runTags);
-                ensureOneOn("runTags", "runName", switchRunName);
-                update_switch_local_storage("switch.runName", settings.switch.runName);
                 create_overview_statistics_graphs();
                 update_projectbar_visibility();
             });
-            switchRunName.addEventListener("click", function () {
+            document.getElementById("switchRunName").addEventListener("click", function () {
                 settings.switch.runName = !settings.switch.runName
                 update_switch_local_storage("switch.runName", settings.switch.runName);
-                ensureOneOn("runName", "runTags", switchRunTags);
-                update_switch_local_storage("switch.runTags", settings.switch.runTags);
                 create_overview_statistics_graphs();
                 update_projectbar_visibility();
             });
@@ -3740,15 +3732,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             Object.entries(graphChangeButtons).forEach(([graphChangeButton, buttonTypes]) => {
                 add_graph_eventlisteners(graphChangeButton, buttonTypes);
             });
-        }
-
-        // If user turns one off while the other is also off,
-        // automatically re-enable the other one.
-        function ensureOneOn(changedKey, otherKey, otherBox) {
-            if (!settings.switch[changedKey] && !settings.switch[otherKey]) {
-                settings.switch[otherKey] = true;
-                otherBox.checked = true;
-            }
         }
 
         /////////////////////////////////////

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -4383,8 +4383,8 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             for (const run of runs) {
                 const projects = new Set();
                 if (settings.switch.runTags) {
-                    const tag = run.tags.split(",").find(t => t.startsWith("project_"));
-                    projects.add(tag);
+                    const projectTags = run.tags.split(",").filter(t => t.startsWith("project_"));
+                    projectTags?.forEach(tag => projects.add(tag));
                 }
                 if (settings.switch.runName) {
                     projects.add(run.name);

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -3182,12 +3182,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             });
             // eventlistener to reset the filters
             document.getElementById("resetFilters").addEventListener("click", function () {
-                document.getElementById("runs").value = "All";
-                const tagElements = document.getElementById("runTag").getElementsByTagName("input");
-                for (const input of tagElements) {
-                    input.checked = false;
-                    if (input.id == "All") input.checked = true;
-                }
+                clear_project_filter();
                 document.getElementById("amount").value = filteredAmountDefault;
                 document.getElementById("metadata").value = "All";
                 setup_lowest_highest_dates(runs);
@@ -4124,6 +4119,26 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
             return filteredData;
         }
 
+        function clear_project_filter() {
+            document.getElementById("runs").value = "All";
+            const tagElements = document.getElementById("runTag").getElementsByTagName("input");
+            for (const input of tagElements) {
+                input.checked = false;
+                if (input.id == "All") input.checked = true;
+            }
+            return;
+        }
+
+        function set_filter_show_current_project(projectName) {
+            if (projectName.startsWith("project_")) {
+                selectedTagSetting = projectName;
+            } else {
+                selectedRunSetting = projectName;
+            }
+            return;
+        }
+
+
         //////////////////////////////////////
         // GRAPH & TABLE CREATION FUNCTIONS //
         //////////////////////////////////////
@@ -4280,17 +4295,8 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                     const cardEl = document.getElementById(`${key}Card${runIndex}`);
                     if (cardEl) {
                         cardEl.addEventListener("click", () => {
-                            document.getElementById("runs").value = "All";
-                            const tagElements = document.getElementById("runTag").getElementsByTagName("input");
-                            for (const input of tagElements) {
-                                input.checked = false;
-                                if (input.id == "All") input.checked = true;
-                            }
-                            if (key.startsWith("project_")) {
-                                selectedTagSetting = key;
-                            } else {
-                                selectedRunSetting = key;
-                            }
+                            clear_project_filter();
+                            set_filter_show_current_project(key);
                             update_menu("menuDashboard");
                         });
                     }

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -3470,6 +3470,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 update_switch_local_storage("switch.runTags", settings.switch.runTags);
                 setup_names_in_overview_select();
                 create_overview_statistics_graphs();
+                create_project_overview();
             });
             document.getElementById("overviewSelectName").addEventListener("change", function () {
                 create_overview_statistics_graphs();
@@ -3983,6 +3984,24 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                 keywordSelect.selectedIndex = keywordNames.length - 1;
             }
         }
+
+      function create_project_overview() {
+        const projectOverviewData = document.getElementById("projectOverviewData");
+        projectOverviewData.innerHTML = "";
+
+        const isDark = document.documentElement.classList.contains("dark-mode");
+        const svg = isDark ? clockDarkSVG: clockLightSVG;
+
+        const projectData = settings.switch.runTags ? projects['by_tag'] : projects['by_name'];
+
+        // create run cards for each project
+        Object.keys(projectData).sort().forEach(projectName => {
+            create_project_cards_container(projectName, projectData[projectName]);
+        });
+
+        // setup collapsables specifically for overview project sections
+        setup_collapsables(projectOverviewData);
+      }
 
       // create project bar (the collapsables below overview statistic) in overview
       function create_project_bar(projectName, projectRuns, totalRunsAmount, passRate) {
@@ -7585,6 +7604,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
         function setup_dasbhoard_graphs() {
             if (settings.menu.overview) {
                 create_overview_statistics_graphs();
+                create_project_overview();
             } else if (settings.menu.dashboard) {
                 create_run_statistics_graph();
                 create_run_donut_graph();

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -4180,8 +4180,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                                         .reverse()
                                         .filter((_, idx) => idx !== i)
                 const averageDuration = durationsForAvg.reduce((a,b) => a + parseFloat(b), 0) / durationsForAvg.length;
-                compareClass = compare_to_average(duration, averageDuration, percentage);
-                if (compareClass) comparesElement.classList.add(compareClass);
+                comparesElement.className = compare_to_average(duration, averageDuration, percentage);
             }
         }
 

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -4185,37 +4185,6 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
 
             const avg = arr => arr.reduce((a, b) => a + parseFloat(b), 0) / arr.length;
 
-            const overviewCard = (name, stats, duration, status, amount, compares, passed_runs, log_path, log_name, svg, runIndex) => `
-        <div class="col-4 overview-card" id="${name}Card${runIndex}">
-            <div class="card border-3 border-${status}">
-                <div class="card-body">
-                    <div class="row">
-                        <div class="col text-center"><h5 class="card-title mb-0">${name}</h5></div>
-                        <div class="col-auto"><h5>#${amount}</h5></div>
-                    </div>
-                    <div class="row">
-                        <div class="col-4 overview-canvas">
-                            <canvas id="${name}Graph${runIndex}"></canvas>
-                        </div>
-                        <div class="col-3 d-flex align-items-center">
-                            <div>
-                                <div class="green-text">Passed: ${stats[0]}</div>
-                                <div class="red-text">Failed: ${stats[1]}</div>
-                                <div class="yellow-text">Skipped: ${stats[2]}</div>
-                            </div>
-                        </div>
-                        <div class="col-5 d-flex align-items-center" style="overflow:auto;">
-                            <div>
-                                <div class="${compares}">${svg} <i>${Math.round(duration)}s</i></div>
-                                <div>Passed Runs: ${passed_runs}%</div>
-                                <a href="#" onclick="event.stopPropagation(); open_log_from_path('${log_path}'); return false;" target="_blank">${log_name}</a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>`;
-
             let overviewHTML = '';
             const overviewDurationPercentage = document.getElementById('overviewDurationPercentage').value;
             const keys = Object.keys(data).sort();
@@ -4244,6 +4213,7 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                     const average = durationsForAvg.length ? avg(durationsForAvg) : duration;
 
                     const compares = compare_to_average(duration, average, overviewDurationPercentage);
+                    const rounded_duration = Math.round(duration);
                     const passedRuns = (runList.reduce((a, b) => a + b.passed_run, 0) / runList.length * 100).toFixed(2);
                     const status = failed > 0 ? 'failed' : skipped > 0 ? 'skipped' : 'passed';
                     const log_path = use_logs ? path : '';
@@ -4253,10 +4223,10 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                         overviewHTML += '<div class="row">';
                     }
 
-                    overviewHTML += overviewCard(
+                    overviewHTML += generate_overview_card_html(
                         key,
                         r.stats,
-                        duration,
+                        rounded_duration,
                         status,
                         runNumber,
                         compares,
@@ -4348,6 +4318,46 @@ Only Changes: Displays only tests that have changed statuses at some point in ti
                     overviewGraphs.push(`${key}Graph${runIndex}`);
                 });
             });
+        }
+
+        // ProjectNamePostfix is for differentiating overview statistic and project specific statistics
+        // since the project specific statistics are differentiated by adding project_ after projectName to the id
+        function generate_overview_card_html(projectName, stats, rounded_duration, status, runNumber, compares, passed_runs, log_path, log_name, svg, runIndex, projectNamePostfix = "") {
+            return `
+            <div class="col-4 overview-card" id="${projectName}${projectNamePostfix}Card${runIndex}">
+                <div class="card border-3 border-${status}">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col text-center"><h5 class="card-title mb-0">${projectName}</h5></div>
+                            <div class="col-auto"><h5>#${runNumber}</h5></div>
+                        </div>
+                        <div class="row">
+                            <div class="col-4 overview-canvas">
+                                <canvas id="${projectName}${projectNamePostfix}Graph${runIndex}"></canvas>
+                            </div>
+                            <div class="col-3 d-flex align-items-center">
+                                <div>
+                                    <div class="green-text">Passed: ${stats[0]}</div>
+                                    <div class="red-text">Failed: ${stats[1]}</div>
+                                    <div class="yellow-text">Skipped: ${stats[2]}</div>
+                                </div>
+                            </div>
+                            <div class="col-5 d-flex align-items-center" style="overflow:auto;">
+                                <div>
+                                    <div class="${compares}" id="${projectName}${projectNamePostfix}RunCardCompares${runIndex}">
+                                        ${svg}
+                                        <i id="${projectName}${projectNamePostfix}RunCardComparesValue${runIndex}" value="${rounded_duration}">
+                                            ${rounded_duration}s
+                                        </i>
+                                    </div>
+                                    <div>Passed Runs: ${passed_runs}%</div>
+                                    <a href="#" onclick="event.stopPropagation(); open_log_from_path('${log_path}'); return false;" target="_blank">${log_name}</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>`;
         }
 
         // function to create run statistics graph in the run section


### PR DESCRIPTION
Hi,

It took me a bit, but I now have a first draft of the project spoiler feature. I anticipate that some modifications will be needed.

I tried to reuse and modularize existing code where possible, but I’m not entirely sure if I struck the right balance between refactoring and code duplication. I could probably modularize more, but I wanted to check in first to ensure the general direction is okay before making larger changes.

Some additions could be better integrated into the existing flow, but I wasn’t sure how to do so without major refactors. I’m happy to tackle those after we discuss what’s acceptable to refactor.

Could you confirm if the resulting UI is roughly what you envisioned?
[debug_dashboard.html](https://github.com/user-attachments/files/23415788/debug_dashboard.html)

### Commit categories chronologically:
#### Create data for runs already grouped by project in python 
Commit: feat(py/dashboard): add project grouped runs dict to dashboard data  
- Generates a dict of runs grouped by project and tag, available in JS.
- Avoids grouping at runtime in JS to save resources.
Specific Questions:
1. Is it alright if I add this extra pre-grouped data?
2. Should this dict be an extra key in the existing data instead of a separate dict? (or something entirely different)
3. Should this logic move to the database module instead?

#### Modularise existing functions
Commits: refactor(js)*
- Adapted existing logic to be reusable for this feature.

#### Add feature functions
Commits: feat(overview/projects)*
- Implemented "leaf" callee functions first, then moved up the call tree to their callers
- Each commit contains only already-defined functions.

Sorry for the open and closing of the PR, I accidentally posted it and panicked :)



