### PR TITLE
fix test cli/removerun on linux

### DIFF
--- a/atest/testsuites/00_cli.robot
+++ b/atest/testsuites/00_cli.robot
@@ -43,7 +43,7 @@ Validate RobotDashboard r
 Validate RobotDashboard removerun
     Validate CLI    command=robotdashboard -d removerun.db --outputfolderpath ${OUTPUTS_FOLDER}
     Validate CLI
-    ...    command=robotdashboard -d removerun.db --removerun index=0:3;-1;6 --removerun "run_start=2025-03-13 00:27:39.871333" --removerun alias=abc,tag=tag1
+    ...    command=robotdashboard -d removerun.db --removerun "index=0:3;-1;6" --removerun "run_start=2025-03-13 00:27:39.871333" --removerun alias=abc,tag=tag1
     ...    expected=removerun
 
 Validate RobotDashboard d


### PR DESCRIPTION
Not having index=xyz quoted results in the shell interpreting the values for index as commands on linux.
Resulting in the test failing due to parsing the index values as commands. 
```bash
/bin/sh: 1: 6: not found
```
I am not sure if this breaks the test on windows, but if I don't misremember, quoting these arguments should work, 
as "run_start=xyz" is also quoted.

[After: log.html](https://github.com/user-attachments/files/23448064/log.html)
[Before: log.html](https://github.com/user-attachments/files/23448085/log.html)

Never mind the UI tests, I think the webengine renders differently on linux and windows, making those cross-platform probably requires running the tests in a container, I can just look at the img diffs and check if they are too far off.