### PR TITLE
fix wrong donut chart first project run card

### DIFF
--- a/robotframework_dashboard/js/graph_creation/overview.js
+++ b/robotframework_dashboard/js/graph_creation/overview.js
@@ -318,7 +318,7 @@ function create_project_run_card(run, projectName, runIndex, runNumber, passRate
                 set_filter_show_current_project(projectName);
                 update_menu("menuDashboard");
             });
-        create_overview_run_donut(run, 0, projectNameForId);
+        create_overview_run_donut(run, runIndex, projectNameForId);
         const versionElement = createdRunCard.querySelector('[data-js-target="apply-version-filter"]');
         versionElement && attach_run_card_version_listener(versionElement, projectName, run.project_version ?? "None");
     }


### PR DESCRIPTION
Hi @timdegroot1996,

thank you again for bringing this bug to my attention in #149 

I investigated the issue and found the culprit: me :sweat_smile: 

```diff
-        create_overview_run_donut(run, 0, projectNameForId);
+        create_overview_run_donut(run, runIndex, projectNameForId);
```

It seems to work now, I checked the log.html files and the donut chart numbers match with the run card and log.html numbers.
[debug_dashboard_with_fix.html](https://github.com/user-attachments/files/23929860/debug_dashboard_with_fix.html)
[debug_dashboard.html](https://github.com/user-attachments/files/23929863/debug_dashboard.html)

I don't quite remember why I put 0 there originally, it's probably a leftover from consolidating the overview statistics and the project section card creation functions.
The 0 here had the effect that the donut chart of the earliest run of the project was applied to the latest run in the else clause if the run card doesn't exist yet in create_project_run_card()

I was a bit unsure if I messed sth else up because 'Tests' and 'Testsuites' have the same run pass/skip/fail stats,
but its consistent with the db
<details><summary>DB output</summary>

```
+----------------------------+-----------+-------+-------+--------+--------+---------+-----------+----------------------------+--------------------+------------------------+--------------------------------------------------------------+----------+-----------------+
| 2025-03-13 00:30:06.726165 | Tests     | Tests | 114   | 106    | 8      | 0       | 17.723    | 2025-03-13 00:30:06.727746 | project_1,dev,prod | output-20250313-003006 | /home/ehaberl/git/github/HuntTheSun/robotframework-dashboard | []       | 2.7             |
|                            |           |       |       |        |        |         |           |                            |                    |                        | /atest/resources/outputs/output-20250313-003006.xml          |          |                 |
+----------------------------+-----------+-------+-------+--------+--------+---------+-----------+----------------------------+--------------------+------------------------+--------------------------------------------------------------+----------+-----------------+
sqlite> SELECT * FROM runs WHERE name='Testsuites' ORDER BY run_start;
+----------------------------+------------+------------+-------+--------+--------+---------+-----------+----------------------------+--------------------+------------------------+--------------------------------------------------------------+----------+-----------------+
|         run_start          | full_name  |    name    | total | passed | failed | skipped | elapsed_s |         start_time         |        tags        |       run_alias        |                             path                             | metadata | project_version |
+----------------------------+------------+------------+-------+--------+--------+---------+-----------+----------------------------+--------------------+------------------------+--------------------------------------------------------------+----------+-----------------+
| 2025-03-13 00:22:22.304104 | Testsuites | Testsuites | 114   | 107    | 7      | 0       | 26.243    | 2025-03-13 00:22:22.305102 | project_1,dev,prod | output-20250313-002222 | /home/ehaberl/git/github/HuntTheSun/robotframework-dashboard | []       | 2.7             |
|                            |            |            |       |        |        |         |           |                            |                    |                        | /atest/resources/outputs/output-20250313-002222.xml          |          |                 |
+----------------------------+------------+------------+-------+--------+--------+---------+-----------+----------------------------+--------------------+------------------------+--------------------------------------------------------------+----------+-----------------+
| 2025-03-13 00:24:31.912429 | Testsuites | Testsuites | 114   | 104    | 9      | 1       | 13.148    | 2025-03-13 00:24:31.913455 | project_1,dev,prod | output-20250313-002431 | /home/ehaberl/git/github/HuntTheSun/robotframework-dashboard | []       | 0.2             |
|                            |            |            |       |        |        |         |           |                            |                    |                        | /atest/resources/outputs/output-20250313-002431.xml          |          |                 |
+----------------------------+------------+------------+-------+--------+--------+---------+-----------+----------------------------+--------------------+------------------------+--------------------------------------------------------------+----------+-----------------+
| 2025-03-13 00:27:03.713995 | Testsuites | Testsuites | 114   | 106    | 8      | 0       | 30.136    | 2025-03-13 00:27:03.716163 | project_1,dev,prod | output-20250313-002703 | /home/ehaberl/git/github/HuntTheSun/robotframework-dashboard | []       | 2.1             |
|                            |            |            |       |        |        |         |           |                            |                    |                        | /atest/resources/outputs/output-20250313-002703.xml          |          |                 |
+----------------------------+------------+------------+-------+--------+--------+---------+-----------+----------------------------+--------------------+------------------------+--------------------------------------------------------------+----------+-----------------+
```

</details>

Anyways, I hope I didn't miss anything, but I went through the old and fixed dashboard side by side, and they seem to match, except the fixed first run card donut chart, of course.
Sorry for introducing a bug :sweat_smile: 
