### PR TITLE
[Enhancement] Sort test names in filter of the "Test Statistics" tab

### DIFF
--- a/robotframework_dashboard/js/filter.js
+++ b/robotframework_dashboard/js/filter.js
@@ -383,7 +383,7 @@ function setup_tests_in_select() {
         return names;
     }, []);
     testSelect.options.add(new Option("All", "All"));
-    testNames.forEach(testName => testSelect.options.add(new Option(testName, testName)));
+    testNames.sort().forEach(testName => testSelect.options.add(new Option(testName, testName)));
 }
 
 // function to update the available testtags to select in the filters


### PR DESCRIPTION
When having a larger number of test cases in the dashboard and in the suite selection, filtering from an ordered list is much easier.