### PR TITLE
[Enhancement] Sort the run tags in filter dialog

### DIFF
--- a/robotframework_dashboard/js/filter.js
+++ b/robotframework_dashboard/js/filter.js
@@ -558,7 +558,7 @@ function setup_runtags_in_select_filter_buttons() {
         </li>
     `;
     const listItems = [listItemTemplate("All")].concat(
-        Array.from(tags).map(tag => listItemTemplate(tag))
+        Array.from(tags).sort().map(tag => listItemTemplate(tag))
     ).join("");
     const tagsSelect = document.getElementById("runTag");
     tagsSelect.innerHTML = andOrTags + listItems;


### PR DESCRIPTION
In our regression testing we are adding a couple of run tags every day. Filtering on some tag patterns is getting difficult if they are populated in an unsorted manner to the drop down list. This PR simply sorts the tags.