### PR TITLE
[Testing]: Scripts and doc to run tests in local docker container

### DIFF
--- a/.github/skills/testing.md
+++ b/.github/skills/testing.md
@@ -30,6 +30,30 @@ Key pabot flags:
 
 ---
 
+## Running Tests in Docker Container
+
+Tests can also be executed within an isolated docker container instead. This limts the dependencies
+in your local setup (like fontweights). A prerequisite is to have a running docker installation.
+
+Running the script `scripts/create-test-image.sh` will create a new docker image with the tag `test-dashboard`. The inline Dockerfile is based on the setup in the `.github/workflows/tests.yml`.
+Running the script again can be used to update amd replace the image based on the latest patches.
+
+The script `scripts/run-in-test-container.sh` can be used to start a new container based on the created image in one of two ways:
+
+```bash
+cd .../robotframework-dashboard
+
+# Running as an interactive shell
+bash scripts/run-in-test-container.sh
+
+# Running in batch mode to execute some connands
+bash scripts/run-in-test-container.sh "bash scripts/tests.sh"
+
+bash scripts/run-in-test-container.sh "robot -t *version* atest/testsuites/00_cli.robot"
+```
+
+The script has to be started from the top level git working directory as it mounts it into the container.
+
 ## Test Dependencies (`requirements-test.txt`)
 
 | Library | Role |

--- a/scripts/create-test-image.sh
+++ b/scripts/create-test-image.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Creates a docker image to used to run tests locally, without
+# installing all the required tool into your system
+
+die() { echo "FATAL: $*"; exit 1; }
+
+docker -v || die "docker seems not being installed"
+
+docker build --tag test-dashboard -f - . <<EOF-EOF
+FROM mcr.microsoft.com/playwright:v1.56.0-jammy
+
+COPY requirements-test.txt /tmp/requirements-test.txt
+RUN << EOF
+    # Ensure pip is installed
+    apt-get update
+    apt-get install -y python3-pip
+
+    # Install Robot Framework and Python dependencies
+    python3 -m pip install --upgrade pip
+    pip3 install -r /tmp/requirements-test.txt
+
+    # Initialize Browser library
+    rfbrowser init
+EOF
+
+# create a workspace directory, where we mount the repo into
+WORKDIR /robotframework-dashboard
+EOF-EOF
+
+# Then run the container in an interactive mode:
+#   docker run -it --rm --ipc=host -v.:/robotframework-dashboard --user 1000:1000 test-dashboard
+# install the dashboard based on the working directory
+#   pip install .
+# add the ~/.local/bin to your path
+#   export PATH=$PATH:~/.local/bin
+# and run the tests, e.g.
+#   robot atest/testsuites/06_filters.robot
+#

--- a/scripts/run-in-test-container.sh
+++ b/scripts/run-in-test-container.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+IMAGE=test-dashboard
+
+die() { echo "FATAL: $*"; exit 1; }
+
+docker -v 2> /dev/null ||
+    die "docker seems not being installed"
+[ -n "$(docker images -q "$IMAGE" 2> /dev/null)" ] || 
+    die "image $IMAGE not found, please run scripts/create-test-image.sh"
+[ -d .git ] ||
+    die "you need to start this script from the toplevel directory of the robotframework-dashboard repository"
+
+my_uid=$(id -u)
+my_gid=$(id -g)
+
+if [ $# = 0 ]; then
+    echo "No arguments given, starting container with interactive terminal"
+    echo "Hint: don't forget to install the dashboard from the git repository in the container:"
+    echo "    pip install . && export PATH=\$PATH:~/.local/bin"
+    echo ""
+    docker run -it --rm --ipc=host -v.:/robotframework-dashboard --user ${my_uid}:${my_gid} test-dashboard
+else
+    echo "Deploying current workingdirectory into the container and running"
+    echo "   $*"
+    echo ""
+    docker run -it --rm --ipc=host -v.:/robotframework-dashboard --user ${my_uid}:${my_gid} test-dashboard \
+        /bin/bash -c \
+            "pip install .; export PATH=\$PATH:~/.local/bin; ${*}"
+fi


### PR DESCRIPTION
Simple setup to create a local docker container to run the acceptance tests in. it is based on the setup.

This reduces the setup required on your local machine and isolates from dependencies with your local setup. In my case the font weight on my system was different compared to the setup when running in GitHub, so that all the screenshot comparisons failed. Running in the docker container provided the same "look and feel".