### PR TITLE
feat: update suite selection settings in statistics tabs and improve dropdown options

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -42,8 +42,9 @@ The **Graphs** tab contains the core configuration options for all charts in the
 | **Bar Graph Edge Rounding (Pixels)** | Controls rounding of bar edges (e.g., `0` = square, `8` = softer). |
 | **Display Timezone Offsets** | Show or hide the timezone offset suffix (e.g. `+02:00`) appended to `run_start` timestamps in graphs and tables. Only has a visible effect on runs that have a stored timezone offset. Runs without an offset are unchanged. |
 | **Convert Timestamps to Local Timezone** | Converts stored `run_start` timestamps from their recorded timezone to the **viewer's browser timezone**. Only applies to runs that have a stored timezone offset — runs without an offset are left unchanged. Useful when runs were recorded in a different timezone than the person viewing the dashboard. |
-| **Suite Statistics - Default suite selection** | Suites to be used when generating the *Suite Statistics*. Can be one of `All Suites Separate`, `All Suites Combine` and `First Suite` (default) |
-| **Test Statistics – Load all suites by default** | When enabled (disabled by default) then the figures in the *Test Statistics* tab are generated from all suites, otherwise from the selected one only. This can mpact the response time depending on the number of suites within the dashboard. |
+| **Suite Statistics – Default suite selection (dropdown)** | Selects which suite(s) are shown by default in the Suite Statistics tab. Options: `All Suites Separate`, `All Suites Combined`, or any individual suite. If the selected suite is removed from the data, the first available suite is used automatically. |
+| **Test Statistics – Default suite selection (dropdown)** | Selects which suite is shown by default in the Test Statistics tab. Options: `All` or any individual suite. If the selected suite is removed from the data, the first available suite is used automatically. |
+| **Test Statistics – Load all suites by default** | When enabled (disabled by default) then the figures in the *Test Statistics* tab are generated from all suites, otherwise from the selected one only. This can impact the response time depending on the number of suites within the dashboard. |
 
 ### Saving Settings
 

--- a/robotframework_dashboard/js/eventlisteners.js
+++ b/robotframework_dashboard/js/eventlisteners.js
@@ -355,7 +355,7 @@ function setup_settings_modal() {
         { key: "show.prefixes", elementId: "togglePrefixes" },
         { key: "show.convertTimezone", elementId: "toggleTimezone" },
         { key: "show.suitesSelectionInSuiteStats", elementId: "toggleSuitesSelectionInSuiteStats", datatype: "string", event: "change" },
-        { key: "show.allSuitesByDefaultInTestStats", elementId: "toggleAllSuitesByDefaultInTestStats" },
+        { key: "show.suitesSelectionInTestStats", elementId: "toggleSuitesSelectionInTestStats", datatype: "string", event: "change" },
     ].forEach(def => {
         const handler = create_toggle_handler(def);
         handler(true);

--- a/robotframework_dashboard/js/filter.js
+++ b/robotframework_dashboard/js/filter.js
@@ -327,8 +327,10 @@ function setup_runs_in_compare_selects() {
 // function to update the available suites to select in the suite filters
 function setup_suites_in_suite_select() {
     const suiteSelectSuites = document.getElementById("suiteSelectSuites");
+    const toggleSuitesSelectionInSuiteStats = document.getElementById("toggleSuitesSelectionInSuiteStats");
     const suiteFolder = document.getElementById("suiteFolder").innerText;
     suiteSelectSuites.innerHTML = "";
+    toggleSuitesSelectionInSuiteStats.innerHTML = "";
     var suiteNames = new Set()
     for (const suite of filteredSuites) {
         if (suiteFolder != "All" && !(suite.full_name.startsWith(suiteFolder + ".") || suite.full_name == suiteFolder)) {
@@ -343,30 +345,63 @@ function setup_suites_in_suite_select() {
     suiteNames = [...suiteNames].sort()
     suiteSelectSuites.options.add(new Option("All Suites Separate", "All Suites Separate"));
     suiteSelectSuites.options.add(new Option("All Suites Combined", "All Suites Combined"));
+    toggleSuitesSelectionInSuiteStats.options.add(new Option("All Suites Separate", "All Suites Separate"));
+    toggleSuitesSelectionInSuiteStats.options.add(new Option("All Suites Combined", "All Suites Combined"));
     suiteNames.forEach(suiteName => {
         suiteSelectSuites.options.add(new Option(suiteName, suiteName));
+        toggleSuitesSelectionInSuiteStats.options.add(new Option(suiteName, suiteName));
     });
-    if (settings.show.suitesSelectionInSuiteStats == 'All Suites Separate') {
+    const suiteStatsSelection = settings.show.suitesSelectionInSuiteStats;
+    if (suiteStatsSelection === 'All Suites Separate') {
         suiteSelectSuites.selectedIndex = 0;
-    } else if (settings.show.suitesSelectionInSuiteStats == 'All Suites Combined') {
+        toggleSuitesSelectionInSuiteStats.selectedIndex = 0;
+    } else if (suiteStatsSelection === 'All Suites Combined') {
         suiteSelectSuites.selectedIndex = 1;
+        toggleSuitesSelectionInSuiteStats.selectedIndex = 1;
     } else {
-        suiteSelectSuites.selectedIndex = 2;
+        let suiteIndex = suiteNames.indexOf(suiteStatsSelection);
+        // If not found or not set, default to first suite and update localStorage
+        if (suiteIndex < 0 && suiteNames.length > 0) {
+            suiteIndex = 0;
+            settings.show.suitesSelectionInSuiteStats = suiteNames[0];
+            set_local_storage_item('show.suitesSelectionInSuiteStats', suiteNames[0]);
+        }
+        const resolvedIndex = suiteIndex >= 0 ? suiteIndex + 2 : 2;
+        suiteSelectSuites.selectedIndex = resolvedIndex;
+        toggleSuitesSelectionInSuiteStats.selectedIndex = resolvedIndex;
     }
 }
 
 // function to update the available suites to select in the test filters
 function setup_suites_in_test_select() {
     const suiteSelectTests = document.getElementById("suiteSelectTests");
+    const suitesSelectionInTestStats = document.getElementById("toggleSuitesSelectionInTestStats");
     suiteSelectTests.innerHTML = "";
+    suitesSelectionInTestStats.innerHTML = "";
     const suiteNames = settings.switch.suitePathsTestSection
         ? [...new Set(filteredSuites.map(suite => suite.full_name))].sort()
         : [...new Set(filteredSuites.map(suite => suite.name))].sort();
     suiteSelectTests.options.add(new Option("All", "All"));
+    suitesSelectionInTestStats.options.add(new Option("All", "All"));
     suiteNames.forEach(suiteName => {
         suiteSelectTests.options.add(new Option(suiteName, suiteName));
+        suitesSelectionInTestStats.options.add(new Option(suiteName, suiteName));
     });
-    suiteSelectTests.selectedIndex = settings.show.allSuitesByDefaultInTestStats ? 0 : 1;
+    const testStatsSelection = settings.show.suitesSelectionInTestStats;
+    if (testStatsSelection === 'All') {
+        suiteSelectTests.selectedIndex = 0;
+        suitesSelectionInTestStats.selectedIndex = 0;
+    } else {
+        let suiteIndex = suiteNames.indexOf(testStatsSelection);
+        // If not found or not set, default to first suite and update localStorage
+        if (suiteIndex < 0 && suiteNames.length > 0) {
+            suiteIndex = 0;
+            settings.show.suitesSelectionInTestStats = suiteNames[0];
+            set_local_storage_item('show.suitesSelectionInTestStats', suiteNames[0]);
+        }
+        suiteSelectTests.selectedIndex = suiteIndex >= 0 ? suiteIndex + 1 : 0;
+        suitesSelectionInTestStats.selectedIndex = suiteIndex >= 0 ? suiteIndex + 1 : 0;
+    }
 }
 
 // function to update the available tests to select in the filters

--- a/robotframework_dashboard/js/variables/settings.js
+++ b/robotframework_dashboard/js/variables/settings.js
@@ -39,7 +39,7 @@ var settings = {
         timezones: false,
         convertTimezone: false,
         suitesSelectionInSuiteStats: "First Suite",
-        allSuitesByDefaultInTestStats: false,
+        suitesSelectionInTestStats: "First Suite",
     },
     theme_colors: {
         light: {

--- a/robotframework_dashboard/templates/dashboard.html
+++ b/robotframework_dashboard/templates/dashboard.html
@@ -739,19 +739,22 @@
                                     <div class="list-group-item d-flex justify-content-between align-items-center">
                                         <span>Suite Statistics - Default suite selection</span>
                                         <div class="d-flex align-items-center">
-                                            <select class="form-select form-select-sm" id="toggleSuitesSelectionInSuiteStats"
-                                                style="width: 200px;">
+                                            <select class="form-select form-select-sm"
+                                                id="toggleSuitesSelectionInSuiteStats" style="width: 200px;">
                                                 <option value="All Suites Separate">All Suites Separate</option>
-                                                <option value="All Suites Combined">All Suites Combined</option>
+                                                <option value="All">First Suite</option>
                                                 <option value="First Suite">First Suite</option>
                                             </select>
                                         </div>
                                     </div>
                                     <div class="list-group-item d-flex justify-content-between align-items-center">
-                                        <span>Test Statistics – Load all suites by default (off by default)</span>
-                                        <div class="form-check form-switch mb-0">
-                                            <input class="form-check-input" type="checkbox" role="switch"
-                                                id="toggleAllSuitesByDefaultInTestStats">
+                                        <span>Test Statistics - Default suite selection</span>
+                                        <div class="d-flex align-items-center">
+                                            <select class="form-select form-select-sm"
+                                                id="toggleSuitesSelectionInTestStats" style="width: 200px;">
+                                                <option value="All Suites Separate">All Suites Separate</option>
+                                                <option value="First Suite">First Suite</option>
+                                            </select>
                                         </div>
                                     </div>
                                 </div>
@@ -888,7 +891,7 @@
                                                 id="resetTextColor">Reset</button>
                                         </div>
                                     </div>
-                                                                        <div class="list-group-item d-flex justify-content-between align-items-center">
+                                    <div class="list-group-item d-flex justify-content-between align-items-center">
                                         <span>Custom Title</span>
                                         <div class="d-flex align-items-center gap-2">
                                             <input class="form-control form-control-sm" type="text"
@@ -902,8 +905,7 @@
                                         <span>Custom Logo <small class="text-muted">(PNG)</small></span>
                                         <div class="d-flex align-items-center gap-2">
                                             <input class="form-control form-control-sm" type="file"
-                                                id="customLogoUpload" accept=".png,image/png"
-                                                style="max-width: 200px;">
+                                                id="customLogoUpload" accept=".png,image/png" style="max-width: 200px;">
                                             <button class="btn btn-outline-light btn-sm"
                                                 id="removeCustomLogo">Reset</button>
                                         </div>


### PR DESCRIPTION
Implements the usage of freely choosable suites to set as the default.

@poWer4aiX, this was what I had in mind, do you think this works with what you were expecting?

You can try it out with below dashboard:
[robot_dashboard.html](https://github.com/user-attachments/files/26317836/robot_dashboard.html)
