### PR TITLE
fix: python-test dockerfile hardcode ubuntu tag

### DIFF
--- a/scripts/docker/test-dashboard-python.dockerfile
+++ b/scripts/docker/test-dashboard-python.dockerfile
@@ -1,5 +1,5 @@
 # Base of the image is the latest ubuntu like 24.04 LTS
-FROM ubuntu:latest
+FROM ubuntu:24.04
 
 RUN << FOE
     # install python


### PR DESCRIPTION
It seems like the current (2026-05-08) ubuntu:latest tag fails to install python3.12  (probably dropped from the repos), at least for me.

Ubuntu 24.04 has EOL until 2029, seems far away enough for now to me.