### PR TITLE
feat: allow/fix no keywords in output.xml processing

### DIFF
--- a/robotframework_dashboard/processors.py
+++ b/robotframework_dashboard/processors.py
@@ -43,7 +43,15 @@ class OutputProcessor:
         self.execution_result.visit(
             KeywordProcessor(self.generation_time, keyword_list)
         )
-        average_keyword_list = self.calculate_keyword_averages(keyword_list) if keyword_list else []
+        if not suite_list:
+            print("  WARNING: No suites found in output, suite data will be empty!")
+        if not test_list:
+            print("  WARNING: No tests found in output, test data will be empty!")
+        if keyword_list:
+            average_keyword_list = self.calculate_keyword_averages(keyword_list)
+        else:
+            print("  WARNING: No keywords found in output, keyword data will be empty!")
+            average_keyword_list = []
         run_list, suite_list = self.merge_run_and_suite_metadata(run_list, suite_list)
         return {
             "runs": run_list,

--- a/robotframework_dashboard/processors.py
+++ b/robotframework_dashboard/processors.py
@@ -43,7 +43,7 @@ class OutputProcessor:
         self.execution_result.visit(
             KeywordProcessor(self.generation_time, keyword_list)
         )
-        average_keyword_list = self.calculate_keyword_averages(keyword_list)
+        average_keyword_list = self.calculate_keyword_averages(keyword_list) if keyword_list else []
         run_list, suite_list = self.merge_run_and_suite_metadata(run_list, suite_list)
         return {
             "runs": run_list,


### PR DESCRIPTION
Hi @timdegroot1996 

for the sake of our pipeline and storage systems, we strip our output.xml of keywords during robotframework tests.
Sadly, robotframework-dashboard runs into an exception here if there are no keywords in the output:
```py
# processors.py function calculate_keyword_averages
run_start = keyword_list[0][0] # keyword list is None if no keywords in xml
```
Would my "fix" be alright or do you dislike the "feature"/"fix"? 
The keywords are empty for the run in the web-ui, no errors in the console.

Sorry for opening a PR directly, I thought a new Issue for a 1-line change would be a bit overkill :)